### PR TITLE
Fix LinguisticObject's `value` to `content`

### DIFF
--- a/content/model/object/aboutness/index.html
+++ b/content/model/object/aboutness/index.html
@@ -12,7 +12,7 @@ The features described in this section are information _about_ the object, and a
 
 ## Description
 
-The main description of the object is provided in the same manner as other such texts; as the `value` of a `LinguisticObject` resource.  The classification for descriptions is _(aat:300080091)_.  The description can include any content that describes the object, and is useful primarily for display to a human user.
+The main description of the object is provided in the same manner as other such texts; as the `content` of a `LinguisticObject` resource.  The classification for descriptions is _(aat:300080091)_.  The description can include any content that describes the object, and is useful primarily for display to a human user.
 
 ```crom
 top = Painting(art=1)


### PR DESCRIPTION
The Object Description section of the model references the non-existent `value` property for a `LinguisticObject`; this change proposes to update the documentation to reference the extant `content` property instead.