### PR TITLE
Update index.html

### DIFF
--- a/content/model/base/index.html
+++ b/content/model/base/index.html
@@ -82,7 +82,7 @@ top.identified_by = ttl
 
 In many cases, current data does not support the level of specificity that the full ontology assumes.  For example, instead of a completely modeled set of parts with materials, many museum collection management systems allow only a single human-readable string for the "medium" or "materials statement".  The same is true in many other situations, including rights or allowable usage statements, dimensions, edition statements and so forth.  Any time that there is a description of the resource that has a more exact scope than just a general description, then this pattern can be used to record that descriptive text.
 
-The pattern makes use of the Linguistic Object class -- a class for resources that identify a particular piece of textual content.  These Linguistic Objects can then refer to any other resource to state what the content is about.  They maintain the statement itself in the `value` property, and the language of the statement (if known) in the `language` property.
+The pattern makes use of the `LinguisticObject` class -- a class for resources that identify a particular piece of textual content.  These Linguistic Objects can then refer to any other resource to state what the content is about.  They maintain the statement itself in the `content` property, and the language of the statement (if known) in the `language` property.
 
 Use cases for this pattern include:
 


### PR DESCRIPTION
Updated `LinguisticObject` `value` property to `content` property, and updated first mention of "the Linguistic Object class" under the "Statements as a Resource" section to "the `LinguisticObject` class" as per other class type references in the documentation. It was unclear if it would be appropriate to modify the second plural reference to Linguistic Objects in the same paragraph?