### PR TITLE
Add Digital Integration `access_point` Context Property

### DIFF
--- a/content/ns/v1/linked-art.json
+++ b/content/ns/v1/linked-art.json
@@ -2731,6 +2731,11 @@
       "@type": "@id", 
       "@container": "@set"
     }, 
+    "access_point": {
+      "@id": "la:access_point", 
+      "@type": "@id", 
+      "@container": "@set"
+    }, 
     "digitally_available_via": {
       "@id": "la:digitally_available_via", 
       "@type": "@id", 


### PR DESCRIPTION
Added the Digital Integration `access_point` property to the context
document for parity with Cromulent’s own `linked-art.json` context
document, so that JSON-LD documents generated by Cromulent, which use
the `access_point` property can be successfully validated against the
Linked.art context.