### PR TITLE
Add EES2 'Train the Trainer' page, home page edits, documentation page edits

### DIFF
--- a/docs/community/projects/ees2/docs/labyrinth/index.md
+++ b/docs/community/projects/ees2/docs/labyrinth/index.md
@@ -1,0 +1,4 @@
+---
+title: ""
+---
+[Back to EES2 Project page](https://linked.art/community/projects/ees2/)

--- a/docs/community/projects/ees2/docs/labyrinth/index.md
+++ b/docs/community/projects/ees2/docs/labyrinth/index.md
@@ -5,4 +5,4 @@ title: ""
 
 # Exploring the Labyrinth with Quire
 
-## An Exemplar Quire Project Based on *Labyrinth: Knossos Myth & Reality* Exhibition
+## An Exemplar Quire Project Based on the *Labyrinth: Knossos Myth & Reality* Exhibition

--- a/docs/community/projects/ees2/docs/labyrinth/index.md
+++ b/docs/community/projects/ees2/docs/labyrinth/index.md
@@ -2,3 +2,7 @@
 title: ""
 ---
 [Back to EES2 Project page](https://linked.art/community/projects/ees2/)
+
+# Exploring the Labyrinth with Quire
+
+## An Exemplar Quire Project Based on *Labyrinth: Knossos Myth & Reality* Exhibition

--- a/docs/community/projects/ees2/docs/quire/index.md
+++ b/docs/community/projects/ees2/docs/quire/index.md
@@ -3,7 +3,15 @@ title: ""
 ---
 [Back to EES2 Project page](https://linked.art/community/projects/ees2/)
 
-# Quire Linked Art Extension Documentation
+# Quire Linked Art Extension
+
+## Quire Linked Art Extension Installation
+
+The Quire Linked Art Extension is available on the [releases](https://github.com/oerc-csi/la-quire/releases) page of the EES2 project's GitHub repository. In the 'Assets' dropdown of the latest version, click on the 'js-files.zip' link to download.
+
+Once you have downloaded the Quire Linked Art Extension, visit our [Training](https://linked.art/community/projects/ees2/docs/training) page for installation instructions.
+
+## Quire Linked Art Extension Documentation
 
 The Linked Art command class for Quire is called `add`. Information about Quire’s command classes can be accessed by running `quire help` in the terminal. `add` is listed as follows:
 
@@ -11,7 +19,7 @@ The Linked Art command class for Quire is called `add`. Information about Quire�
 
 All commands begin with `quire`. To run the `add` command, start by typing `quire add` in the terminal. The elements that follow `quire add` are arguments and options. The arguments and options included in the command determine what the software will do. Those in angled brackets are required, and those in square brackets are optional (except for `[id1]` when adding a figure to an existing object, see section 1.2)
 
-## **1 Arguments**
+### **1 Arguments**
 
 There are four arguments: `<thing>`, `<uri>`, `[id1]`, and `[id2]`.  
 `<thing>` can be `object`, `object.figure`, `figure`, or `spreadsheet`.  
@@ -19,7 +27,7 @@ There are four arguments: `<thing>`, `<uri>`, `[id1]`, and `[id2]`.
 `[id1]` and `[id2]` can be any string, or the word `accession` can be passed to use the accession number of the object as the ID.  
 The following sections explain how these arguments are used in commands to accomplish specific tasks.
 
-### **1.1 Adding an object to objects.yaml**
+#### **1.1 Adding an object to objects.yaml**
 
 To add an object to objects.yaml, run:
 
@@ -31,7 +39,7 @@ Optionally, the user can create their own ID for the object by running:
 
 If the user does not pass an ID, one will be automatically generated. The ID can be any string that is not already being used as an ID. The accession number of the object can be retrieved and used as the ID by passing the word `accession` as `[id1]`.
 
-### **1.2 Adding a figure to an existing object in objects.yaml**
+#### **1.2 Adding a figure to an existing object in objects.yaml**
 
 To add a figure to an existing object in objects.yaml, run:
 
@@ -41,7 +49,7 @@ To add a figure to an existing object in objects.yaml, run:
 
 `quire add object <uri> [id1] [id2]`
 
-### **1.3 Adding a figure to figures.yaml**
+#### **1.3 Adding a figure to figures.yaml**
 
 To add a figure to figures.yaml run:
 
@@ -49,17 +57,17 @@ To add a figure to figures.yaml run:
 
 As usual, a unique ID or the word `accession` can be passed as [id1]. If an ID is not provided, one will be generated.
 
-### **1.4 Browse all Linked Art data for an object in a spreadsheet**
+#### **1.4 Browse all Linked Art data for an object in a spreadsheet**
 
 The `spreadsheet` arg provides a way for the user to easily browse Linked Art by generating a CSV file containing all the fields of a Linked Art record and their values/contents in the project folder.
 
 `quire add spreadsheet <uri>`
 
-## **2 Choosing fields, field order, and field names**
+### **2 Choosing fields, field order, and field names**
 
 The user has the ability to choose which fields are retrieved from the Linked Art record, the order in which they are displayed, and their names. Field selection and order are handled by the object_display_order section of the objects.yaml file, and field names can be changed from defaults in the objectFieldNames section of the config.yaml file.
 
-### **2.1 objects.yaml object_display_order**
+#### **2.1 objects.yaml object_display_order**
 
 There are 21 fields currently supported by the Linked Art extension in addition to object title, which is always retrieved:
 
@@ -89,7 +97,7 @@ To choose fields to retrieve and their order of appearance, simply include them 
 
 **IMPORTANT:** the field names in the object_display_order section of objects.yaml must match the names provided in the objectFieldNames section of config.yaml
 
-### **2.2 config.yaml objectFieldNames**
+#### **2.2 config.yaml objectFieldNames**
 
 The user can choose the names of the fields by changing the default names in config.yaml. The  following are the internal names (left) and default/chosen names (right) as they appear in config.yaml:
 
@@ -122,7 +130,7 @@ creator: creator => creator: artist name
 
 Remember to then change the field name in the object_display_order of objects.yaml as well.
 
-## **3 Processing Multiple URIs and ‘activity’ URIs**
+### **3 Processing Multiple URIs and ‘activity’ URIs**
 
 It is possible to process multiple URIs at once by passing the URIs in double quotations and separated by spaces.
 
@@ -141,17 +149,17 @@ The program will detect that the URI is an ‘activity’ URI and start an inter
 
 After a selection is made, the program will process all the objects in the ‘activity’ record and/or generate a spreadsheet of information about the objects.
 
-## **4 Options**
+### **4 Options**
 
 There are two options: `--dry-run` and `--force`.
 
-### **4.1 Preview an entry before adding to objects.yaml or figures.yaml**
+#### **4.1 Preview an entry before adding to objects.yaml or figures.yaml**
 
 The user has the option to preview an entry before it is added to objects.yaml or figures.yaml by using the `--dry-run` option. When `--dry-run` is passed, an entry will not be added and an image will not be downloaded. Instead, the entry will be logged in the console for the user to see.
 
 `quire add <thing> <uri> [id1] [id2] --dry-run`
 
-### **4.2 Refetching Linked Art and overwriting cache**
+#### **4.2 Refetching Linked Art and overwriting cache**
 
 When the user runs commands that retrieve Linked Art data and figures, the data and figure hashes will be added to caches. When a URI that has been passed is passed again, the program will retrieve Linked Art data from the cache instead of making new http requests to refetch the data.
 
@@ -159,7 +167,7 @@ The user has the ability to change the fields they wish to retrieve as they work
 
 `quire add <thing> <uri> [id1] [id2] --force`
 
-### **4.3 Resizing images**
+#### **4.3 Resizing images**
 
 By default, full-size images of objects are retrieved. The `--resize` option allows the user to resize images if they wish to download a version with a smaller file size.
 
@@ -172,7 +180,7 @@ When ‘--resize’ is passed, an interaction will start:
 
 After entering the number or percentage of pixels for resizing, the image will be resized accordingly before being downloaded as usual.
 
-### **4.4 Selecting fields in interactive mode**
+#### **4.4 Selecting fields in interactive mode**
 
 The primary method of selecting the fields to be retrieved is by including the field names in the object_display_list at the top of the objects.yaml file. The `--interactive` option provides an alternative way of making this selection.
 

--- a/docs/community/projects/ees2/docs/training/index.md
+++ b/docs/community/projects/ees2/docs/training/index.md
@@ -1,0 +1,25 @@
+---
+title: ""
+---
+[Back to EES2 Project page](https://linked.art/community/projects/ees2/)
+
+# Train the Trainer
+
+## A Tutorial for Using Linked Art with Quire
+
+### Overview
+The Enriching Exhibition Stories project held sessions at the Digital Humanities at Oxford Summer School (DHOxSS) from August 12-16, 2024, at St Anne’s College, Oxford. The workshops, titled “Enriching Exhibition Stories with Quire” (Parts 1 and 2), provided participants with a comprehensive introduction to Quire, an open-source software developed by Getty for creating rich, exhibition-centric digital narratives, as well as practical training on effectively using the software.
+
+The project team demonstrated how to use Quire for crafting digital stories based on the Ashmolean Museum’s acclaimed 2023 exhibition *Labyrinth: Knossos, Myth and Reality*. Participants were trained to use the Linked Art extension, which was developed by the Enriching Exhibition Stories project, and engaged in hands-on exercises to design and implement their own projects with this extension.
+
+We are providing the materials created for these sessions here, free-to-use and open-source. These materials can serve as training aids for anyone interested in using Quire and the Linked Art extension, supporting researchers, educators, and cultural heritage professionals in their digital storytelling.
+
+Explore the links below to access the training materials.
+
+### Resources
+- **Slides** ([PDF](https://github.com/oerc-csi/la-quire/raw/main/docs/training/training-slides.pdf)|[PPTX](https://github.com/oerc-csi/la-quire/raw/main/docs/training/training-slides.pptx))
+- **Installation Instructions**
+    - MacOS ([PDF](https://github.com/oerc-csi/la-quire/raw/main/docs/training/installation-instructions-macOS.pdf)|[DOCX](https://github.com/oerc-csi/la-quire/raw/main/docs/training/installation-instructions-macOS.docx))
+    - Windows ([PDF](https://github.com/oerc-csi/la-quire/raw/main/docs/training/installation-instructions-windows.pdf)|[DOCX](https://github.com/oerc-csi/la-quire/raw/main/docs/training/installation-instructions-windows.docx))
+- **Exercise Sheet** ([PDF](https://github.com/oerc-csi/la-quire/raw/main/docs/training/exercise-sheet.pdf)|[DOCX](https://github.com/oerc-csi/la-quire/raw/main/docs/training/exercise-sheet.docx))
+- **Quire Template** ([ZIP](https://github.com/oerc-csi/la-quire/raw/main/docs/training/quire-template.zip))

--- a/docs/community/projects/ees2/docs/training/index.md
+++ b/docs/community/projects/ees2/docs/training/index.md
@@ -24,8 +24,10 @@ Explore the links below to access the training materials.
     - Windows ([PDF](https://github.com/oerc-csi/la-quire/raw/main/docs/training/installation-instructions-windows.pdf)|[DOCX](https://github.com/oerc-csi/la-quire/raw/main/docs/training/installation-instructions-windows.docx))
 - **Exercise Sheet** ([PDF](https://github.com/oerc-csi/la-quire/raw/main/docs/training/exercise-sheet.pdf)|[DOCX](https://github.com/oerc-csi/la-quire/raw/main/docs/training/exercise-sheet.docx))
 - **Quire Template for Exercises** ([ZIP](https://github.com/oerc-csi/la-quire/raw/main/docs/training/quire-template.zip))
+    - Run ‘npm install’ in the template folder to install dependencies
 - **Exercise Sheet Walk-Through Video** ([YouTube](https://youtu.be/y0z8u-r9UCY))
-    - 00:00 - Exercise 2: Give your project a title and add your name ([YouTube](https://www.youtube.com/watch?v=y0z8u-r9UCY&t=0s))
+    - 00:00 - Exercise 1: Download and preview the Quire project Template ([YouTube](https://www.youtube.com/watch?v=y0z8u-r9UCY&t=0s))
+    - 01:50 - Exercise 2: Give your project a title and add your name ([YouTube](https://www.youtube.com/watch?v=y0z8u-r9UCY&t=110s))
     - 04:00 - Exercise 3: Write a brief introduction ([YouTube](https://www.youtube.com/watch?v=y0z8u-r9UCY&t=240s))
     - 05:09 - Exercise 4: Add a figure from a Linked Art resource ([YouTube](https://www.youtube.com/watch?v=y0z8u-r9UCY&t=309s))
     - 08:25 - Exercise 5: Add an object from a Linked Art resource ([YouTube](https://www.youtube.com/watch?v=y0z8u-r9UCY&t=505s))

--- a/docs/community/projects/ees2/docs/training/index.md
+++ b/docs/community/projects/ees2/docs/training/index.md
@@ -10,7 +10,7 @@ title: ""
 ### Overview
 The Enriching Exhibition Stories project held sessions at the Digital Humanities at Oxford Summer School (DHOxSS) from August 12-16, 2024, at St Anne’s College, Oxford. The workshops, titled “Enriching Exhibition Stories with Quire” (Parts 1 and 2), provided participants with a comprehensive introduction to Quire, an open-source software developed by Getty for creating rich, exhibition-centric digital narratives, as well as practical training on effectively using the software.
 
-The project team demonstrated how to use Quire for crafting digital stories based on the Ashmolean Museum’s acclaimed 2023 exhibition *Labyrinth: Knossos, Myth and Reality*. Participants were trained to use the Linked Art extension, which was developed by the Enriching Exhibition Stories project, and engaged in hands-on exercises to design and implement their own projects with this extension.
+The project team demonstrated how to use Quire for crafting digital stories based on the Ashmolean Museum’s acclaimed 2023 exhibition *Labyrinth: Knossos, Myth & Reality*. Participants were trained to use the Linked Art extension, which was developed by the Enriching Exhibition Stories project, and engaged in hands-on exercises to design and implement their own projects with this extension.
 
 We are providing the materials created for these sessions here, free-to-use and open-source. These materials can serve as training aids for anyone interested in using Quire and the Linked Art extension, supporting researchers, educators, and cultural heritage professionals in their digital storytelling.
 

--- a/docs/community/projects/ees2/docs/training/index.md
+++ b/docs/community/projects/ees2/docs/training/index.md
@@ -24,7 +24,7 @@ Explore the links below to access the training materials.
     - Windows ([PDF](https://github.com/oerc-csi/la-quire/raw/main/docs/training/installation-instructions-windows.pdf)|[DOCX](https://github.com/oerc-csi/la-quire/raw/main/docs/training/installation-instructions-windows.docx))
 - **Exercise Sheet** ([PDF](https://github.com/oerc-csi/la-quire/raw/main/docs/training/exercise-sheet.pdf)|[DOCX](https://github.com/oerc-csi/la-quire/raw/main/docs/training/exercise-sheet.docx))
 - **Quire Template for Exercises** ([ZIP](https://github.com/oerc-csi/la-quire/raw/main/docs/training/quire-template.zip))
-    - Run ‘npm install’ in the template folder to install dependencies
+    - Run `npm install` in the template folder to install dependencies
 - **Exercise Sheet Walk-Through Video** ([YouTube](https://youtu.be/y0z8u-r9UCY))
     - 00:00 - Exercise 1: Download and preview the Quire project Template ([YouTube](https://www.youtube.com/watch?v=y0z8u-r9UCY&t=0s))
     - 01:50 - Exercise 2: Give your project a title and add your name ([YouTube](https://www.youtube.com/watch?v=y0z8u-r9UCY&t=110s))

--- a/docs/community/projects/ees2/docs/training/index.md
+++ b/docs/community/projects/ees2/docs/training/index.md
@@ -17,9 +17,18 @@ We are providing the materials created for these sessions here, free-to-use and 
 Explore the links below to access the training materials.
 
 ### Resources
-- **Slides** ([PDF](https://github.com/oerc-csi/la-quire/raw/main/docs/training/training-slides.pdf)|[PPTX](https://github.com/oerc-csi/la-quire/raw/main/docs/training/training-slides.pptx))
-- **Installation Instructions**
+- **Introductory Slides** ([PDF](https://github.com/oerc-csi/la-quire/raw/main/docs/training/training-slides.pdf)|[PPTX](https://github.com/oerc-csi/la-quire/raw/main/docs/training/training-slides.pptx))
+- **Installation instructions for Quire and Linked Art Extension**
+    - [Download the Extension](https://linked.art/community/projects/ees2/docs/quire/)
     - MacOS ([PDF](https://github.com/oerc-csi/la-quire/raw/main/docs/training/installation-instructions-macOS.pdf)|[DOCX](https://github.com/oerc-csi/la-quire/raw/main/docs/training/installation-instructions-macOS.docx))
     - Windows ([PDF](https://github.com/oerc-csi/la-quire/raw/main/docs/training/installation-instructions-windows.pdf)|[DOCX](https://github.com/oerc-csi/la-quire/raw/main/docs/training/installation-instructions-windows.docx))
 - **Exercise Sheet** ([PDF](https://github.com/oerc-csi/la-quire/raw/main/docs/training/exercise-sheet.pdf)|[DOCX](https://github.com/oerc-csi/la-quire/raw/main/docs/training/exercise-sheet.docx))
-- **Quire Template** ([ZIP](https://github.com/oerc-csi/la-quire/raw/main/docs/training/quire-template.zip))
+- **Quire Template for Exercises** ([ZIP](https://github.com/oerc-csi/la-quire/raw/main/docs/training/quire-template.zip))
+- **Exercise Sheet Walk-Through Video** ([YouTube](https://youtu.be/y0z8u-r9UCY))
+    - 00:00 - Exercise 2: Give your project a title and add your name ([YouTube](https://www.youtube.com/watch?v=y0z8u-r9UCY&t=0s))
+    - 04:00 - Exercise 3: Write a brief introduction ([YouTube](https://www.youtube.com/watch?v=y0z8u-r9UCY&t=240s))
+    - 05:09 - Exercise 4: Add a figure from a Linked Art resource ([YouTube](https://www.youtube.com/watch?v=y0z8u-r9UCY&t=309s))
+    - 08:25 - Exercise 5: Add an object from a Linked Art resource ([YouTube](https://www.youtube.com/watch?v=y0z8u-r9UCY&t=505s))
+    - 11:08 - Exercise 6: Add a figure to an existing object ([YouTube](https://www.youtube.com/watch?v=y0z8u-r9UCY&t=668s))
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/y0z8u-r9UCY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/docs/community/projects/ees2/index.md
+++ b/docs/community/projects/ees2/index.md
@@ -22,6 +22,7 @@ title: "Enriching Exhibition Stories: Adding Voices to Quire"
 
 ## Resources
 
+- Access the [Quire Linked Art Extension](https://linked.art/community/projects/ees2/docs/quire/) page for installation instructions and detailed documentation on how to use the extension to work with Linked Art in your Quire projects.
 - Explore our [Training](https://linked.art/community/projects/ees2/docs/training) page for a comprehensive tutorial on using Linked Art with Quire.
 
 ## Project Summary

--- a/docs/community/projects/ees2/index.md
+++ b/docs/community/projects/ees2/index.md
@@ -11,16 +11,7 @@ title: "Enriching Exhibition Stories: Adding Voices to Quire"
     <img src="/community/projects/ees2/YCBA logo.png" alt="Yale Center for British Art" height="67" />
 </div>
 <br>
-*Enriching Exhibition Stories: Adding Voices to Quire (project reference AH/Y006011/1) is a project funded by the UK [Arts and Humanities Research Council](https://ahrc.ukri.org/) (AHRC) and led by the [University of Oxford](https://www.ox.ac.uk/), working in partnership with the [University of Edinburgh](https://www.ed.ac.uk/), the [Ashmolean Museum](https://www.ashmolean.org/), and [Yale University](https://www.yale.edu/)*.
-
-## DHOxSS Links
-- [Quire Linked Art Extension Documentation](https://linked.art/community/projects/ees2/docs/quire)  
-- [Quire Installation Instructions](https://linked.art/community/projects/ees2/docs/quire/quire_installation_instructions.docx)  
-- [Linked Art Extension Files (la_quire_extension.zip)](https://linked.art/community/projects/ees2/docs/quire/la_quire_extension.zip)  
-- [Quire Template (quire_template.zip)](https://drive.google.com/file/d/1Cfb7bfgQJeVR6THAWrk9QKwxeazKjgoM/view?usp=sharing)  
-- [Demo](https://drive.google.com/file/d/1XFSEEqePwsPYl6PjCkpFOwyJLX73wLCS/view?usp=sharing)  
-- [Tuesday Session Slides](https://linked.art/community/projects/ees2/docs/quire/slides.pdf)  
-- [Thursday Session Exercise Sheet](https://linked.art/community/projects/ees2/docs/quire/exercise_sheet.docx)  
+*Enriching Exhibition Stories: Adding Voices to Quire (project reference AH/Y006011/1) is a project funded by the UK [Arts and Humanities Research Council](https://ahrc.ukri.org/) (AHRC) and led by the [University of Oxford](https://www.ox.ac.uk/), working in partnership with the [University of Edinburgh](https://www.ed.ac.uk/), the [Ashmolean Museum](https://www.ashmolean.org/), and [Yale University](https://www.yale.edu/)*. 
 
 ## Project News
 - **Getty Quire Workshop.** In June 2024, Enriching Exhibition Stories ran a Quire user workshop with our partners at Getty, followed by associated activities at the Getty Villa and IIIF conference. [Read more…](https://linked.art/community/projects/ees2/news/quire_workshop)
@@ -28,6 +19,10 @@ title: "Enriching Exhibition Stories: Adding Voices to Quire"
     - How easily can Linked Art data be retrieved for inclusion in Quire? Sasha Tan considers modelling, versioning, and local practice, and how software tools can help. [Read more…](https://linked.art/community/projects/ees2/news/quire_workshop/linked_art_retrieval_tool_practicum)
     - How do people use Quire? Thorsteinn Imi King reports on a comparative evaluation of Quire publications and the benefits of Linked Art for digital curators and editors. [Read more...](https://linked.art/community/projects/ees2/news/quire_workshop/quire_comparison_practicum)
 - **Quire Linked Art Extension Documentation.** [Documentation](https://linked.art/community/projects/ees2/docs/quire) for the Linked Art Extension for Quire developed by the Enriching Exhibition Stories project is now available.
+
+## Resources
+
+- Explore our [Training](https://linked.art/community/projects/ees2/docs/training) page for a comprehensive tutorial on using Linked Art with Quire.
 
 ## Project Summary
 Traditional exhibition catalogues are extremely informative documents, but may be daunting, perhaps even intimidating, both to those who write them and those who read them. Enriching Exhibition Stories will help museums more easily create supplemental digital forms of exhibition narrative which speak to, and can be voiced by, a wider and more diverse range of perspectives than those who usually engage with exhibitions.


### PR DESCRIPTION
A new page (community/projects/ees2/docs/training/) for the EES2 project has been created documenting the 'Train the Trainer' event organized for DHOxSS 2024 and providing training materials for the Quire Linked Art Extension. The EES2 home page (community/projects/ees2/) has been edited: the 'DHOxSS Links' section has been removed and a 'Resources' section has been added. An installation section has been added to the EES2 documentation page (community/projects/ees2/docs/quire/). Preparation for a page documenting the Labyrinth exemplar Quire project (community/projects/ees2/docs/labyrinth/) has been started, but no links lead to it yet, as it is not finished.