### PR TITLE
Add link in Resources section of EES2 home page and edit documentation

### DIFF
--- a/docs/community/projects/ees2/docs/quire/index.md
+++ b/docs/community/projects/ees2/docs/quire/index.md
@@ -112,6 +112,8 @@ The `spreadsheet` arg provides a way for the user to easily browse Linked Art by
 
 The user has the ability to choose which fields are retrieved from the Linked Art record, the order in which they are displayed, and their names. Field selection and order are handled by the object_display_order section of the objects.yaml file, and field names can be changed from defaults in the objectFieldNames section of the config.yaml file.
 
+The object’s title and Linked Art URI will be retrieved regardless of their presence in the object_display_order. The extension relies on the URI for functionality such as duplicate prevention. To ensure optimal results, it is recommended to keep URIs in the objects listed in the object_list. However, the URI can be omitted from rendered content by excluding it from the object_display_order.
+
 #### **2.1 objects.yaml object_display_order**
 
 There are 21 fields currently supported by the Linked Art extension in addition to object title, which is always retrieved:

--- a/docs/community/projects/ees2/index.md
+++ b/docs/community/projects/ees2/index.md
@@ -26,7 +26,8 @@ title: "Enriching Exhibition Stories: Adding Voices to Quire"
 ## Resources
 
 - The Quire Linked Art Extension extension fetches data from a Linked Art API and merges object records and images (via IIIF) into a Quire project. For installation instructions and comprehensive documentation, visit this [page](https://linked.art/community/projects/ees2/docs/quire/).
-- Explore our [Training](https://linked.art/community/projects/ees2/docs/training) page for a comprehensive tutorial on using Linked Art with Quire.
+- Dr. Andrew Shapland has reused materials created for his 2023 exhibition *Labyrinth: Knossos, Myth & Reality* at the Ashmolean within new Quire-generated learning resources for the permanent Aegean World gallery. Visit this [page](https://linked.art/community/projects/ees2/docs/labyrinth) for access to the the resulting resources and to learn more.
+- Explore our [Training](https://linked.art/community/projects/ees2/docs/training) page for a comprehensive tutorial on using the Quire Linked Art extension.
 - [Find out more](https://linked.art/community/projects/ees2/docs/outreach/) about our outreach trial with the Ashmolean and Rumble Museums and Cheney School, including lesson plans and accompanying teaching resources.
 - Read our May 2024 [survey](https://linked.art/community/projects/ees2/docs/quire_survey/) of existing Quire use.
 - Check out [latool.js](https://linked.art/community/projects/ees2/docs/latool), a script that fetches and processes Linked Art from a provided URL.


### PR DESCRIPTION
Added a bullet point to the Resources section of the EES2 home page at community/projects/ees2 linking to the new Labyrinth page at community/projects/ees2/docs/labyrinth. Edited the documentation at community/projects/ees2/docs/quire.