### PR TITLE
Standardize language across docs

### DIFF
--- a/docs/model/exhibition/index.md
+++ b/docs/model/exhibition/index.md
@@ -147,16 +147,15 @@ top.member_of = model.Set(ident="exhset")
 
 ## Integration with Other Parts of the Model
 
-### Provenance Events for Exhibitions
+### Provenance Activities for Exhibitions
 
-As objects used for exhibitions frequently come from many different organizations, it is useful and interesting to track the custody of the object as well as the ownership.  This event is modeled in the same way as other [Custody](/model/provenance/custody/) changes.  
+As objects used for exhibitions frequently come from many different organizations, it is useful and interesting to track the custody of the object as well as the ownership. This activity is modeled in the same way as other [Custody](/model/provenance/custody/) changes.  
 
-For each exhibition, the custody of the object is transferred from the previous custodian to the next. In the simple case of a single venue for the exhibition, the first transfer is likely to be from the owner to the organization responsible for the exhibition, and then at the end of the exhibition, the custody is transferred back again.  In a more complex scenario with multiple venues, each organization hosting the exhibition will likely transfer custody to the next in the sequence.  
+For each exhibition, the custody of the object is transferred from the previous custodian to the next. In the simple case of a single venue for the exhibition, the first transfer is likely to be from the owner to the organization responsible for the exhibition, and then at the end of the exhibition, the custody is transferred back again. In a more complex scenario with multiple venues, each organization hosting the exhibition will likely transfer custody to the next in the sequence.
 
-However, when the object being exhibited at the location is owned by the same organization, there is no transfer of custody. The equivalent activity is likely to be simply moving the object from its regular location to the exhibition space. This is described in the same way as other [Movement](/model/provenance/movement/) events.
+However, when the object being exhibited at the location is owned by the same organization, there is no transfer of custody. The equivalent activity is likely to be simply moving the object from its regular location to the exhibition space. This is described in the same way as other [Movement](/model/provenance/movement/) activities.
 
 The provenance activities can be linked to the Exhibition by asserting that they are `part_of` the Exhibition activity.
-
 
 ### Exhibition Specific Titles
 

--- a/docs/model/provenance/acquisition.md
+++ b/docs/model/provenance/acquisition.md
@@ -1,5 +1,5 @@
 ---
-title: Object Acquisition and Loan
+title: Object Acquisition
 up_href: "/model/provenance/"
 up_label: "Provenance"
 ---

--- a/docs/model/provenance/index.md
+++ b/docs/model/provenance/index.md
@@ -5,22 +5,21 @@ up_label: "Model Overview"
 ---
 
 
-
 ## Introduction
 
-The general model for describing the provenance of an object is to track the events in which the object of interest is created or discovered, transferred between owners or custodians, until it is lost, destroyed or in its present location.  For example a painting's provenance starts when the artist paints it, and then there are events in which ownership of the painting is transferred from the artist to its first owner, and then on to subsequent owners. The details of those transfers are the primary data to be collected in the provenance part of the model.
+The general model for describing the provenance of an object is to track a series of [activities](../event) in which the object of interest is created or discovered, transferred between owners or custodians, until it is lost, destroyed or in its present location. For example a painting's provenance starts when the artist paints it, and then there are activities in which the ownership of the painting is transferred from the artist to its first owner, and then on to subsequent owners. The details of those transfers are the primary data to be collected in this section of the model.
 
-In between the events there are periods of time in which the ownership does not change, but other interesting events may still occur, including change of custody, such as when the painting is loaned out for an [exhibition](../exhibition/), [conservation](../conservation/), revaluation or other activities that would establish the object's location and ownership at a point in time.
+In between provenance activities there are periods of time in which the ownership does not change, but other interesting activities may still occur, including changes of custody, such as when the painting is loaned out for an [exhibition](../exhibition/), [conservation](../conservation/), revaluation or other activities that would establish a different location and custodian of an object at a point in time.
 
-The provenance of an object is described as a series of activities, built on top of the basic patterns. For a single entry in the chain of provenance there are frequently multiple activities bundled together into a "Provenance Event" of interest.  These bundled activities could be the transfer of ownership, the transfer of custody, physically moving the object, a payment of money or the promise of some future action. This section documents the basic framework in which provenance events are described and subsequent sections will document specific use cases.
+The provenance of an object is described as a series of activities, built on top of the basic patterns. For a single entry in the chain of provenance there are frequently multiple activities bundled together. These bundled activities could be the transfer of ownership, the transfer of custody, physically moving the object, a payment of money or the promise of some future action. This section documents the framework in which provenance activities are described and subsequent sections will document specific use cases.
 
-The chain of events starts with the production of the object by its creator, and ends only with its destruction. As there can only be one of each, they are focused on the object rather than on the activity and have a different pattern. This information is covered in the [Object](/model/object/production/) section of the model, as while the events are part of the lifecycle of the object, they are not modeled in the same way as other Provenance Events.
+The chain of provenance starts with the production of the object by its creator, and ends only with its destruction. While production and destruction are part of the lifecycle of the object, they are not modeled in the same way as other provenance activities. As there can only be one of each of these activities, they are focused on the object and have a different pattern covered in the [Object](/model/object/production/) section of the model.
 
-## Provenance Event
+## Provenance Activities
 
-Provenance Events are wrapper activities which represent the context in which several more granular events occur, and represent the overall event that is tracked in the chain, rather than the specific legal and physical changes that affect one or more objects.  For example, an exchange of one object for another is a single provenance entry that involves the transfer of ownership of the two objects and thus that event would appear in both objects' timelines. It might also be accompanied by an additional payment of money, promise of an activity or other contributions. 
+Provenance Activities are wrappers that give context and represent the overall changes in the chain of provenance, rather than the specific legal and physical changes that affect one or more objects. For example, an exchange of one object for another is a single provenance activity that involves the transfer of ownership of the two objects and thus that activity would appear in both objects' timelines. It might also be accompanied by an additional payment of money, promise of an activity or other contributions. 
 
-Provenance Events have all of the regular properties and relationships, as documented in the [baseline patterns](/model/base/). In particular, the relationships to actors, places and time reflect the overall event, and can be further specified in the separate parts if they are different and known.  
+Provenance Activities have all of the regular properties and relationships, as documented in the [baseline patterns](/model/base/). In particular, the relationships to agents, places and time reflect the overall activity, and can be further specified in the separate parts if they are different and known.  
 
 __Example:__
 
@@ -94,26 +93,26 @@ top.before = vocab.ProvenanceEntry(label="foure_durand")
 
 ## Parts
 
-The Provenance Event likely includes some number of further, more specific aspects. These aspects are described in more detail in the following, linked sections.
+The Provenance Activity likely includes some number of further, more specific aspects. These aspects are described in more detail in the following, linked sections.
 
 
 ### Acquisition and Payments
 
-The majority of provenance events include the change of ownership of an object, or its acquisition.  Many of these acquisitions involve the payment of money, or the exchange of another object, for the transfer of ownership - a purchase rather than a gift.
+The majority of provenance activities include the change of ownership of an object, or its acquisition.  Many of these acquisitions involve the payment of money, or the exchange of another object, for the transfer of ownership - a purchase rather than a gift.
 
-These sorts of provenance events are documented in the [Acquisition](acquisition) section.
+These sorts of provenance activities are documented in the [Acquisition](acquisition) section.
 
 ### Transfers of Custody
 
-There are also provenance events that do not involve a transfer of legal ownership, only the transfer of custody or guardianship. Use cases for this include permanent loans, that might otherwise seem like ownership, and temporary loans, such as for exhibitions.  Theft or looting are both illegal transfers of custody, as the object should be restituted to its rightful owner, and the simple loss of an object is the transfer of custody to no entity in particular.
+There are also provenance activities that do not involve a transfer of legal ownership, only the transfer of custody or guardianship. Use cases for this include permanent loans, that might otherwise seem like ownership, and temporary loans, such as for exhibitions.  Theft or looting are both illegal transfers of custody, as the object should be restituted to its rightful owner, and the simple loss of an object is the transfer of custody to no entity in particular.
 
-These sorts of provenance events are documented in the [Custody](custody) section.
+These sorts of provenance activities are documented in the [Custody](custody) section.
 
 ### Discovery or Rediscovery of an Object
 
 Objects can be lost, sometimes for very long periods of time, and then encountered by a different culture or set of people than the ones that lost it. As this might happen several times in the history of an object, and there are ownership and custody implications of the rediscovery, encounters of these sorts are part of the provenance record of the object. Knowledge about previous encounters or the production of the object may not be known, meaning that it is possible that this is the first known entry in the provenance chain.
 
-These sorts of provenance events are documented in the [Encountering an Object](encounters) section.
+These sorts of provenance activities are documented in the [Encountering an Object](encounters) section.
 
 ### Acquisition of a Right
 
@@ -121,7 +120,7 @@ Some transfers of ownership are more complex than simply acquiring an object and
 
 Note that this section is complicated, and likely only valuable to specialized databases of provenance. Feedback is welcome to improve its usability and accuracy in representing the transfer of non-physical ownership.
 
-These sorts of provenance events are documented in the [Rights](rights) section.
+These sorts of provenance activities are documented in the [Rights](rights) section.
 
 ### Promise of Activity
 
@@ -133,13 +132,13 @@ Promises are documented in the [Promises](promises) section, and bids are auctio
 
 Although not often explicitly documented, most provenance activities also involve the physical relocation of the acquired object. This is especially interesting for use with describing exhibitions, where the location is explicitly known over a period of time, or in cases where such movement is extraordinary in some way, such as the relocation of a building or other "immovable" piece of art.
 
-These sorts of provenance events are documented in the [Movement](movement) section.
+These sorts of provenance activities are documented in the [Movement](movement) section.
 
 ### Unknown Type of Transfer
 
 When working from incomplete documentary evidence it is frequently difficult to determine exactly what sort of exchange took place in the past. For example, an archive or letter might say that the object "went to the museum", which would be insufficient to distinguish between a transfer of ownership, a transfer of custody, or merely physical movement of the object. While every effort should be made to be precise in provenance document whenever possible, it is also important to capture uncertain activities.
 
-These sorts of provenance events are document in the [Transfer](transfer) section.
+These sorts of provenance activities are document in the [Transfer](transfer) section.
 
 
 ## Specific Uses

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,7 @@ nav:
       - Collections: model/collection/index.md
       - Provenance:
         - Object Provenance: model/provenance/index.md
-        - Acquisitions and Loans: model/provenance/acquisition.md
+        - Acquisitions: model/provenance/acquisition.md
         - Auctions: model/provenance/auctions.md
         - Changes of Custody: model/provenance/custody.md
         - Encounters with Objects: model/provenance/encounters.md


### PR DESCRIPTION
- [x] Remove mention to loans in the acquisition page and nav menu (Provenance Model). Currently the nav menu for the Provenance model mentions [Acquisitions and Loans](https://linked.art/model/provenance/acquisition/), but loans are described in the [Changes of Custody](https://linked.art/model/provenance/custody/) page.
- [x] #750
- [ ] #747 

------
Preview: https://deploy-preview-748--linked-art.netlify.app/