### PR TITLE
Add, extend and refactor SPARQL queries

### DIFF
--- a/docs/api/rels/1/activityCarriedOutByAgent.md
+++ b/docs/api/rels/1/activityCarriedOutByAgent.md
@@ -12,19 +12,23 @@ See the related [model documentation](/model/base/#events-and-activities /model/
 
 From the record for the National Gallery of Art, the record for the Manet exhibition activity would be in the response
 
-
 ### Details
 
 * Class Given: Agent
 * Returns Class: Activity
 * Relationship: carriedOutBy
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?activity WHERE {
-  BIND (<%current%>AS ?group)
-.  ?activity crm:P14_carried_out_by ?group .
-   }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?activity
+WHERE {
+  {
+    ?activity crm:P14_carried_out_by $current .
+  } UNION {
+    $current crm:P14i_performed ?activity .
+  }
+}
+```

--- a/docs/api/rels/1/activityCarriedOutByAgent.md
+++ b/docs/api/rels/1/activityCarriedOutByAgent.md
@@ -21,7 +21,7 @@ From the record for the National Gallery of Art, the record for the Manet exhibi
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?activity
 WHERE {

--- a/docs/api/rels/1/activityCausedByActivity.md
+++ b/docs/api/rels/1/activityCausedByActivity.md
@@ -21,7 +21,7 @@ From the record for a fire that damaged a statue, the record for the conservatio
 ### SPARQL
 
 ```sparql
-PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/> .
+PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/>
 
 SELECT DISTINCT ?activity
 WHERE {

--- a/docs/api/rels/1/activityCausedByActivity.md
+++ b/docs/api/rels/1/activityCausedByActivity.md
@@ -12,16 +12,23 @@ See the related [model documentation]()
 
 From the record for a fire that damaged a statue, the record for the conservation activity to repair the statue would be in the response
 
-
 ### Details
 
 * Class Given: Event,Activity
 * Returns Class: Event,Activity
 * Relationship: 
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/> .
 
+SELECT DISTINCT ?activity
+WHERE {
+  {
+    ?activity sci:O13i_is_triggered_by $current .
+  } UNION {
+    $current sci:O13_triggers ?activity .
+  }
+}
+```

--- a/docs/api/rels/1/activityClassifiedAsConcept.md
+++ b/docs/api/rels/1/activityClassifiedAsConcept.md
@@ -21,7 +21,7 @@ From the record for the concept of Exhibitions, the record for "Manet and Modern
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?activity
 WHERE {

--- a/docs/api/rels/1/activityClassifiedAsConcept.md
+++ b/docs/api/rels/1/activityClassifiedAsConcept.md
@@ -12,16 +12,23 @@ See the related [model documentation](/model/base/#types-and-classifications)
 
 From the record for the concept of Exhibitions, the record for "Manet and Modern Beauty" would be in the response
 
-
 ### Details
 
 * Class Given: Concept
 * Returns Class: Temporal
 * Relationship: classifiedAs
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?activity
+WHERE {
+  {
+    ?activity crm:P2_has_type $current .
+  } UNION {
+    $current crm:P2i_is_type_of ?activity .
+  }
+}
+```

--- a/docs/api/rels/1/activityPartOfActivity.md
+++ b/docs/api/rels/1/activityPartOfActivity.md
@@ -12,16 +12,23 @@ See the related [model documentation](/model/base/#parts)
 
 From the record for the Bronze Age, the record for the Middle Bronze Age would be in the response
 
-
 ### Details
 
 * Class Given: Temporal
 * Returns Class: Temporal
 * Relationship: 
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?activity
+WHERE {
+  {
+    ?activity crm:P9_consists_of $current .
+  } UNION {
+    $current crm:P9i_forms_part_of ?activity .
+  }
+}
+```

--- a/docs/api/rels/1/activityPartOfActivity.md
+++ b/docs/api/rels/1/activityPartOfActivity.md
@@ -21,7 +21,7 @@ From the record for the Bronze Age, the record for the Middle Bronze Age would b
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?activity
 WHERE {

--- a/docs/api/rels/1/activityParticipantAgent.md
+++ b/docs/api/rels/1/activityParticipantAgent.md
@@ -21,7 +21,7 @@ From the record for Tristan Tzara, the record for Cabaret Voltaire would be in t
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?activity
 WHERE {

--- a/docs/api/rels/1/activityParticipantAgent.md
+++ b/docs/api/rels/1/activityParticipantAgent.md
@@ -12,17 +12,23 @@ See the related [model documentation]()
 
 From the record for Tristan Tzara, the record for Cabaret Voltaire would be in the response. 
 
-
 ### Details
 
 * Class Given: Agent
 * Returns Class: Event, Activity
 * Relationship: participant
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?activity WHERE {
-  ?activity crm:P11_had_participant <%current%>.  }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?activity
+WHERE {
+  {
+    ?activity crm:P11_had_participant $current .
+  } UNION {
+    $current crm:P11i_participated_in ?activity .
+  }
+}
+```

--- a/docs/api/rels/1/activityTookPlaceAtPlace.md
+++ b/docs/api/rels/1/activityTookPlaceAtPlace.md
@@ -12,16 +12,23 @@ See the related [model documentation](/model/base/#events-and-activities)
 
 From the record for New Haven, the record for the exhibition activity Life, Liberty and the Pursuit of Happiness would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Event, Activity
 * Relationship: tookPlaceAt
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?activity
+WHERE {
+  {
+    ?activity crm:P7_took_place_at $current .
+  } UNION {
+    $current crm:P7i_witnessed ?activity .
+  }
+}
+```

--- a/docs/api/rels/1/activityTookPlaceAtPlace.md
+++ b/docs/api/rels/1/activityTookPlaceAtPlace.md
@@ -21,7 +21,7 @@ From the record for New Haven, the record for the exhibition activity Life, Libe
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?activity
 WHERE {

--- a/docs/api/rels/1/activityUsedObject.md
+++ b/docs/api/rels/1/activityUsedObject.md
@@ -12,16 +12,23 @@ See the related [model documentation]()
 
 From the record for the Night Watch, the record for the conservation work on the painting would be in the response
 
-
 ### Details
 
 * Class Given: HumanMadeObject
 * Returns Class: Activity
 * Relationship: used
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?activity
+WHERE {
+  {
+    ?activity crm:P31_has_modified $current .
+  } UNION {
+    $current crm:P31i_was_modified_by ?activity .
+  }
+}
+```

--- a/docs/api/rels/1/activityUsedObject.md
+++ b/docs/api/rels/1/activityUsedObject.md
@@ -21,7 +21,7 @@ From the record for the Night Watch, the record for the conservation work on the
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?activity
 WHERE {

--- a/docs/api/rels/1/activityUsedSet.md
+++ b/docs/api/rels/1/activityUsedSet.md
@@ -12,16 +12,23 @@ See the related [model documentation](/model/exhibition/#exhibition-activity)
 
 From the record for the set of objects shown in an exhibition, the record for the exhibition's activity would be in the response
 
-
 ### Details
 
 * Class Given: Set
 * Returns Class: Activity
 * Relationship: used
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?activity
+WHERE {
+  {
+    ?activity crm:P16_used_specific_object $current .
+  } UNION {
+    $current crm:P16i_was_used_for ?activity .
+  }
+}
+```

--- a/docs/api/rels/1/activityUsedSet.md
+++ b/docs/api/rels/1/activityUsedSet.md
@@ -21,7 +21,7 @@ From the record for the set of objects shown in an exhibition, the record for th
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?activity
 WHERE {

--- a/docs/api/rels/1/activityUsedWork.md
+++ b/docs/api/rels/1/activityUsedWork.md
@@ -19,9 +19,17 @@ See the related [model documentation]()
 * Returns Class: Activity
 * Relationship: used
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?activity
+WHERE {
+  {
+    ?activity crm:P15_was_influenced_by $current .
+  } UNION {
+    $current crm:P15i_influenced ?activity .
+  }
+}
+```

--- a/docs/api/rels/1/activityUsedWork.md
+++ b/docs/api/rels/1/activityUsedWork.md
@@ -22,7 +22,7 @@ See the related [model documentation]()
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?activity
 WHERE {

--- a/docs/api/rels/1/agentActiveAtPlace.md
+++ b/docs/api/rels/1/agentActiveAtPlace.md
@@ -12,16 +12,28 @@ See the related [model documentation](/model/actor/#active-dates)
 
 From the record for Harlem, New York, the record for A.Philip Randolph would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Agent
 * Relationship: activeAt
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?agent
+WHERE {
+  {
+    $current crm:P7i_witnessed ?activity .
+  } UNION {
+    ?activity crm:P7_took_place_at $current .
+  }
+  {
+    ?activity crm:P14_carried_out_by ?agent .
+  } UNION {
+    ?agent crm:P14i_perfomed ?activity .
+  }
+}
+```

--- a/docs/api/rels/1/agentActiveAtPlace.md
+++ b/docs/api/rels/1/agentActiveAtPlace.md
@@ -21,7 +21,7 @@ From the record for Harlem, New York, the record for A.Philip Randolph would be 
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?agent
 WHERE {

--- a/docs/api/rels/1/agentBornOrFormedAtPlace.md
+++ b/docs/api/rels/1/agentBornOrFormedAtPlace.md
@@ -21,7 +21,7 @@ From the record for Harlem, New York, the record for Ayize Jama-Everett would be
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?agent
 WHERE {

--- a/docs/api/rels/1/agentBornOrFormedAtPlace.md
+++ b/docs/api/rels/1/agentBornOrFormedAtPlace.md
@@ -12,16 +12,28 @@ See the related [model documentation](/model/actor/#birth-and-death-formation-an
 
 From the record for Harlem, New York, the record for Ayize Jama-Everett would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Agent
 * Relationship: born / formed
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?agent
+WHERE {
+  {
+    ?agent crm:P98i_was_born|crm:P95i_was_formed_by ?activity .
+  } UNION {
+    ?activity crm:P98_brought_into_life|crm:P95_has_formed ?agent .
+  }
+  {
+    ?activity crm:P7_took_place_at $current .
+  } UNION {
+    $current crm:P7i_witnessed ?activity .
+  }
+}
+```

--- a/docs/api/rels/1/agentClassifiedAsConcept.md
+++ b/docs/api/rels/1/agentClassifiedAsConcept.md
@@ -28,7 +28,7 @@ WHERE {
   {
     ?agent crm:P2_has_type $current .
   } UNION {
-    $current crm:P2_is_type_of ?agent .
+    $current crm:P2i_is_type_of ?agent .
   }
 }
 ```

--- a/docs/api/rels/1/agentClassifiedAsConcept.md
+++ b/docs/api/rels/1/agentClassifiedAsConcept.md
@@ -12,16 +12,23 @@ See the related [model documentation](/model/base/#types-and-classifications)
 
 From the record for the concept of the Dutch nationality, the record for Rembrandt would be in the response
 
-
 ### Details
 
 * Class Given: Concept
 * Returns Class: Agent
 * Relationship: classifiedAs
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?agent
+WHERE {
+  {
+    ?agent crm:P2_has_type $current .
+  } UNION {
+    $current crm:P2_is_type_of ?agent .
+  }
+}
+```

--- a/docs/api/rels/1/agentClassifiedAsConcept.md
+++ b/docs/api/rels/1/agentClassifiedAsConcept.md
@@ -21,7 +21,7 @@ From the record for the concept of the Dutch nationality, the record for Rembran
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?agent
 WHERE {

--- a/docs/api/rels/1/agentDiedOrDissolvedAtPlace.md
+++ b/docs/api/rels/1/agentDiedOrDissolvedAtPlace.md
@@ -12,16 +12,28 @@ See the related [model documentation](/model/actor/#birth-and-death-formation-an
 
 From the record for Harlem, New York, the record for Howard Johnson-1941-2021 would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Agent
 * Relationship: died / dissolved
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?agent
+WHERE {
+  {
+    ?agent crm:P100i_died_in|crm:P95i_was_formed_by ?activity .
+  } UNION {
+    ?activity crm:P100_was_death_of|crm:P99_dissolved ?agent .
+  }
+  {
+    ?activity crm:P7_took_place_at $current .
+  } UNION {
+    $current crm:P7i_witnessed ?activity .
+  }
+}
+```

--- a/docs/api/rels/1/agentDiedOrDissolvedAtPlace.md
+++ b/docs/api/rels/1/agentDiedOrDissolvedAtPlace.md
@@ -21,7 +21,7 @@ From the record for Harlem, New York, the record for Howard Johnson-1941-2021 wo
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?agent
 WHERE {

--- a/docs/api/rels/1/agentMemberOfGroup.md
+++ b/docs/api/rels/1/agentMemberOfGroup.md
@@ -12,19 +12,23 @@ See the related [model documentation](/model/actor/#organization-membership)
 
 From the record for Societe Anonyme, Katherine Dreier and Fortunato Depero would all be in the response
 
-
 ### Details
 
 * Class Given: Group
 * Returns Class: Agent
 * Relationship: memberOf
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?member WHERE {
-   BIND (<%current%> AS ?group)
-.   ?member crm:P107i_is_current_or_former_member_of ?group .
- }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?agent
+WHERE {
+  {
+    ?agent crm:P107i_is_current_or_former_member_of $current .
+  } UNION {
+    $current crm:P107_has_current_or_former_member ?agent .
+  }
+}
+```

--- a/docs/api/rels/1/agentMemberOfGroup.md
+++ b/docs/api/rels/1/agentMemberOfGroup.md
@@ -21,7 +21,7 @@ From the record for Societe Anonyme, Katherine Dreier and Fortunato Depero would
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?agent
 WHERE {

--- a/docs/api/rels/1/agentResidentAtPlace.md
+++ b/docs/api/rels/1/agentResidentAtPlace.md
@@ -21,7 +21,7 @@ From the record for Brooklyn, New York the record for E.V. Day would be in the r
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?agent
 WHERE {

--- a/docs/api/rels/1/agentResidentAtPlace.md
+++ b/docs/api/rels/1/agentResidentAtPlace.md
@@ -12,16 +12,23 @@ See the related [model documentation](/model/actor/#residence-as-a-place)
 
 From the record for Brooklyn, New York the record for E.V. Day would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Agent
 * Relationship: residenceAt
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?agent
+WHERE {
+  {
+    ?agent crm:P74_has_current_or_former_residence $current .
+  } UNION {
+    $current crm:P74i_is_current_or_former_residence_of ?agent .
+  }
+}
+```

--- a/docs/api/rels/1/conceptBroaderConcept.md
+++ b/docs/api/rels/1/conceptBroaderConcept.md
@@ -21,7 +21,7 @@ From the record for the concept for Visual Art object types, the record for Pain
 ### SPARQL
 
 ```sparql
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#> .
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
 SELECT DISTINCT ?concept
 WHERE {

--- a/docs/api/rels/1/conceptBroaderConcept.md
+++ b/docs/api/rels/1/conceptBroaderConcept.md
@@ -12,16 +12,23 @@ See the related [model documentation](/model/concept/#partitioning-versus-classi
 
 From the record for the concept for Visual Art object types, the record for Paintings would be in the response
 
-
 ### Details
 
 * Class Given: Concept
 * Returns Class: Concept
 * Relationship: broader
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#> .
 
+SELECT DISTINCT ?concept
+WHERE {
+  {
+    $current skos:broader ?concept .
+  } UNION {
+    ?concept skos:narrower $current .
+  }
+}
+```

--- a/docs/api/rels/1/conceptClassifiedAsConcept.md
+++ b/docs/api/rels/1/conceptClassifiedAsConcept.md
@@ -21,7 +21,7 @@ From the record for the concept of Nationalities, the record for Dutch would be 
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?concept
 WHERE {

--- a/docs/api/rels/1/conceptClassifiedAsConcept.md
+++ b/docs/api/rels/1/conceptClassifiedAsConcept.md
@@ -28,7 +28,7 @@ WHERE {
   {
     $current crm:P2_has_type ?concept .
   } UNION {
-    ?concept crm:P2_is_type_of $current .
+    ?concept crm:P2i_is_type_of $current .
   }
 }
 ```

--- a/docs/api/rels/1/conceptClassifiedAsConcept.md
+++ b/docs/api/rels/1/conceptClassifiedAsConcept.md
@@ -12,16 +12,23 @@ See the related [model documentation](/model/concept/#partitioning-versus-classi
 
 From the record for the concept of Nationalities, the record for Dutch would be in the response
 
-
 ### Details
 
 * Class Given: Concept
 * Returns Class: Concept
 * Relationship: classifiedAs
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?concept
+WHERE {
+  {
+    $current crm:P2_has_type ?concept .
+  } UNION {
+    ?concept crm:P2_is_type_of $current .
+  }
+}
+```

--- a/docs/api/rels/1/conceptCreationCausedByActivity.md
+++ b/docs/api/rels/1/conceptCreationCausedByActivity.md
@@ -22,7 +22,7 @@ See the related [model documentation]()
 ### SPARQL
 
 ```
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?concept
 WHERE {

--- a/docs/api/rels/1/conceptCreationCausedByActivity.md
+++ b/docs/api/rels/1/conceptCreationCausedByActivity.md
@@ -19,9 +19,17 @@ See the related [model documentation]()
 * Returns Class: Concept
 * Relationship: 
 
-
 ### SPARQL
-```
 
 ```
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?concept
+WHERE {
+  {
+    $current crm:P94i_was_created_by ?activity .
+  } UNION {
+    ?activity crm:P94_has_created $current .
+  }
+}
+```

--- a/docs/api/rels/1/conceptInfluencedByActivity.md
+++ b/docs/api/rels/1/conceptInfluencedByActivity.md
@@ -21,7 +21,7 @@ From the record for the 15th Century (a Period), the record for the History of F
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?concept
 WHERE {

--- a/docs/api/rels/1/conceptInfluencedByActivity.md
+++ b/docs/api/rels/1/conceptInfluencedByActivity.md
@@ -12,16 +12,28 @@ See the related [model documentation](/model/concept/#creation-and-influences)
 
 From the record for the 15th Century (a Period), the record for the History of France in the 15th Century would be in the response
 
-
 ### Details
 
 * Class Given: Temporal
 * Returns Class: Concept
 * Relationship: 
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?concept
+WHERE {
+  {
+    $current crm:P94i_was_created_by ?activity .
+  } UNION {
+    ?activity crm:P94_has_created ?concept .
+  }
+  {
+    ?activity crm:P15_was_influenced_by $current .
+  } UNION {
+    $current crm:P15i_influenced ?activity .
+  }
+}
+```

--- a/docs/api/rels/1/conceptInfluencedByAgent.md
+++ b/docs/api/rels/1/conceptInfluencedByAgent.md
@@ -12,18 +12,33 @@ See the related [model documentation](/model/concept/#creation-and-influences)
 
 From the record for Rembrandt, the record for the concept 'Rembrandt -- Aesthetics' would be in the response
 
-
 ### Details
 
 * Class Given: Agent
 * Returns Class: Concept
 * Relationship: influencedBy
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?concept WHERE {
-   ?concept crm:P94i_was_created_by ?creation .
-   ?creation crm:P15_was_influenced_by <%current%>. }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?concept
+WHERE {
+  {
+    $current crm:P94i_was_created_by ?activity .
+  } UNION {
+    ?activity crm:P94_has_created ?concept .
+  }
+  {
+    ?activity crm:P15_was_influenced_by $current .
+  } UNION {
+    $current crm:P15i_influenced ?activity .
+  }
+  {
+    $current a crm:E21_Person .
+  } UNION {
+    $current a crm:E74_Group .
+  }
+}
+```

--- a/docs/api/rels/1/conceptInfluencedByAgent.md
+++ b/docs/api/rels/1/conceptInfluencedByAgent.md
@@ -21,7 +21,7 @@ From the record for Rembrandt, the record for the concept 'Rembrandt -- Aestheti
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?concept
 WHERE {

--- a/docs/api/rels/1/conceptInfluencedByConcept.md
+++ b/docs/api/rels/1/conceptInfluencedByConcept.md
@@ -21,7 +21,7 @@ From the record for the concept of History, the record for History of France wou
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?concept
 WHERE {

--- a/docs/api/rels/1/conceptInfluencedByConcept.md
+++ b/docs/api/rels/1/conceptInfluencedByConcept.md
@@ -12,16 +12,29 @@ See the related [model documentation](/model/concept/#creation-and-influences)
 
 From the record for the concept of History, the record for History of France would be in the response
 
-
 ### Details
 
 * Class Given: Concept
 * Returns Class: Concept
 * Relationship: influencedBy
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?concept
+WHERE {
+  {
+    $current crm:P94i_was_created_by ?activity .
+  } UNION {
+    ?activity crm:P94_has_created ?concept .
+  }
+  {
+    ?activity crm:P15_was_influenced_by $current .
+  } UNION {
+    $current crm:P15i_influenced ?activity .
+  }
+  $current a crm:E55_Type .
+}
+```

--- a/docs/api/rels/1/conceptInfluencedByObject.md
+++ b/docs/api/rels/1/conceptInfluencedByObject.md
@@ -23,7 +23,7 @@ From the record for the Night Watch, the concept of the Reception of the Night W
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?concept
 WHERE {

--- a/docs/api/rels/1/conceptInfluencedByObject.md
+++ b/docs/api/rels/1/conceptInfluencedByObject.md
@@ -21,7 +21,22 @@ From the record for the Night Watch, the concept of the Reception of the Night W
 
 
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?concept
+WHERE {
+  {
+    $current crm:P94i_was_created_by ?activity .
+  } UNION {
+    ?activity crm:P94_has_created ?concept .
+  }
+  {
+    ?activity crm:P15_was_influenced_by $current .
+  } UNION {
+    $current crm:P15i_influenced ?activity .
+  }
+  $current a crm:E22_Human-Made_Object .
+}
+```

--- a/docs/api/rels/1/conceptInfluencedByPlace.md
+++ b/docs/api/rels/1/conceptInfluencedByPlace.md
@@ -21,7 +21,7 @@ From the record for the Netherlands, the record for Dutch Golden Age Paintings w
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?concept
 WHERE {

--- a/docs/api/rels/1/conceptInfluencedByPlace.md
+++ b/docs/api/rels/1/conceptInfluencedByPlace.md
@@ -12,16 +12,29 @@ See the related [model documentation](/model/concept/#creation-and-influences)
 
 From the record for the Netherlands, the record for Dutch Golden Age Paintings would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Concept
 * Relationship: influencedBy
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?concept
+WHERE {
+  {
+    $current crm:P94i_was_created_by ?activity .
+  } UNION {
+    ?activity crm:P94_has_created ?concept .
+  }
+  {
+    ?activity crm:P15_was_influenced_by $current .
+  } UNION {
+    $current crm:P15i_influenced ?activity .
+  }
+  $current a crm:E53_Place .
+}
+```

--- a/docs/api/rels/1/conceptInfluencedBySet.md
+++ b/docs/api/rels/1/conceptInfluencedBySet.md
@@ -19,9 +19,24 @@ See the related [model documentation](/model/concept/#creation-and-influences)
 * Returns Class: Concept
 * Relationship: influencedBy
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX la: <https://linked.art/ns/terms/> .
 
+SELECT DISTINCT ?concept
+WHERE {
+  {
+    $current crm:P94i_was_created_by ?activity .
+  } UNION {
+    ?activity crm:P94_has_created ?concept .
+  }
+  {
+    ?activity crm:P15_was_influenced_by $current .
+  } UNION {
+    $current crm:P15i_influenced ?activity .
+  }
+  $current a la:Set .
+}
+```

--- a/docs/api/rels/1/conceptInfluencedBySet.md
+++ b/docs/api/rels/1/conceptInfluencedBySet.md
@@ -22,8 +22,8 @@ See the related [model documentation](/model/concept/#creation-and-influences)
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX la: <https://linked.art/ns/terms/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX la: <https://linked.art/ns/terms/>
 
 SELECT DISTINCT ?concept
 WHERE {

--- a/docs/api/rels/1/conceptInfluencedByWork.md
+++ b/docs/api/rels/1/conceptInfluencedByWork.md
@@ -21,7 +21,7 @@ From the record for The Lord of the Rings, the record for the concept of the His
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?concept
 WHERE {

--- a/docs/api/rels/1/conceptInfluencedByWork.md
+++ b/docs/api/rels/1/conceptInfluencedByWork.md
@@ -12,16 +12,29 @@ See the related [model documentation](/model/concept/#creation-and-influences)
 
 From the record for The Lord of the Rings, the record for the concept of the History of Middle-Earth would be in the response
 
-
 ### Details
 
 * Class Given: Work
 * Returns Class: Concept
 * Relationship: influencedBy
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?concept
+WHERE {
+  {
+    $current crm:P94i_was_created_by ?activity .
+  } UNION {
+    ?activity crm:P94_has_created ?concept .
+  }
+  {
+    ?activity crm:P15_was_influenced_by $current .
+  } UNION {
+    $current crm:P15i_influenced ?activity .
+  }
+  $current a crm:E89_Propositional_Object .
+}
+```

--- a/docs/api/rels/1/conceptMemberOfSet.md
+++ b/docs/api/rels/1/conceptMemberOfSet.md
@@ -12,16 +12,25 @@ See the related [model documentation](/model/collection/#features)
 
 From the record for the AAT concept scheme (a Set), the record for AAT's Primary Name concept would be in the response
 
-
 ### Details
 
 * Class Given: Set
 * Returns Class: Concept
 * Relationship: memberOf
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX la: <https://linked.art/ns/terms/> .
 
+SELECT DISTINCT ?concept
+WHERE {
+  {
+    ?concept la:member_of $current .
+  } UNION {
+    $current la:has_member ?concept .
+  }
+  ?concept a crm:E55_Type .
+}
+```

--- a/docs/api/rels/1/conceptMemberOfSet.md
+++ b/docs/api/rels/1/conceptMemberOfSet.md
@@ -21,8 +21,8 @@ From the record for the AAT concept scheme (a Set), the record for AAT's Primary
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX la: <https://linked.art/ns/terms/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX la: <https://linked.art/ns/terms/>
 
 SELECT DISTINCT ?concept
 WHERE {

--- a/docs/api/rels/1/entityMemberOfSet.md
+++ b/docs/api/rels/1/entityMemberOfSet.md
@@ -12,16 +12,24 @@ See the related [model documentation](/model/collection/#features)
 
 From the record for the Getty's painting department's objects, the record for Spring would be in the response 
 
-
 ### Details
 
 * Class Given: Set
 * Returns Class: Entity
 * Relationship: memberOf
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX la: <https://linked.art/ns/terms/> .
 
+SELECT DISTINCT ?entity
+WHERE {
+  {
+    ?entity la:member_of $current .
+  } UNION {
+    $current la:has_member ?entity .
+  }
+  $current a la:Set .
+}
+```

--- a/docs/api/rels/1/entityMemberOfSet.md
+++ b/docs/api/rels/1/entityMemberOfSet.md
@@ -21,7 +21,7 @@ From the record for the Getty's painting department's objects, the record for Sp
 ### SPARQL
 
 ```sparql
-PREFIX la: <https://linked.art/ns/terms/> .
+PREFIX la: <https://linked.art/ns/terms/>
 
 SELECT DISTINCT ?entity
 WHERE {

--- a/docs/api/rels/1/groupActiveAtPlace.md
+++ b/docs/api/rels/1/groupActiveAtPlace.md
@@ -21,7 +21,7 @@ From the record for Paris France, the record for Goupil & Cie would be in the re
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?group
 WHERE {

--- a/docs/api/rels/1/groupActiveAtPlace.md
+++ b/docs/api/rels/1/groupActiveAtPlace.md
@@ -12,16 +12,29 @@ See the related [model documentation](/model/actor/#active-dates)
 
 From the record for Paris France, the record for Goupil & Cie would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Group
 * Relationship: activeAt
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?group
+WHERE {
+  {
+    ?group crm:P14i_performed ?activity .
+  } UNION {
+    ?activity crm:P14_carried_out_by ?group .
+  }
+  {
+    ?activity crm:P7_took_place_at $current .
+  } UNION {
+    $current crm:P7i_witnessed ?activity .
+  }
+  $current a crm:E53_Place .
+}
+```

--- a/docs/api/rels/1/groupDissolvedAtPlace.md
+++ b/docs/api/rels/1/groupDissolvedAtPlace.md
@@ -21,7 +21,7 @@ From the record for New Haven Connecticut, the record for Société Anonyme woul
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?group
 WHERE {

--- a/docs/api/rels/1/groupDissolvedAtPlace.md
+++ b/docs/api/rels/1/groupDissolvedAtPlace.md
@@ -12,20 +12,29 @@ See the related [model documentation](/model/actor/#birth-and-death-formation-an
 
 From the record for New Haven Connecticut, the record for Société Anonyme would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Group
 * Relationship: dissolvedAt
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?group WHERE {
-   BIND(<%current%>as ?where)
-   ?group crm:P99i_was_dissolved_by ?dissolution .
-    ?dissolution crm:P7_took_place_at ?where .
- }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?group
+WHERE {
+  {
+    ?group crm:P99i_was_dissolved_by ?activity .
+  } UNION {
+    ?activity crm:P99_dissolved ?group .
+  }
+  {
+    ?activity crm:P7_took_place_at $current .
+  } UNION {
+    $current crm:P7i_witnessed ?activity .
+  }
+  $current a crm:E53_Place .
+}
+```

--- a/docs/api/rels/1/groupFormedAtPlace.md
+++ b/docs/api/rels/1/groupFormedAtPlace.md
@@ -12,20 +12,29 @@ See the related [model documentation](/model/actor/#birth-and-death-formation-an
 
 From the record for Los Altos California, the record for Apple Computers would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Group
 * Relationship: formedAt
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?group WHERE {
-   BIND(<%current%>as ?where)
-   ?group crm:P95i_was_formed_by ?formation .
-    ?formation crm:P7_took_place_at ?where .
- }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?group
+WHERE {
+  {
+    ?group crm:P95i_was_formed_by ?activity .
+  } UNION {
+    ?activity crm:P95_has_formed ?group .
+  }
+  {
+    ?activity crm:P7_took_place_at $current .
+  } UNION {
+    $current crm:P7i_witnessed ?activity .
+  }
+  $current a crm:E53_Place .
+}
+```

--- a/docs/api/rels/1/groupFormedAtPlace.md
+++ b/docs/api/rels/1/groupFormedAtPlace.md
@@ -21,7 +21,7 @@ From the record for Los Altos California, the record for Apple Computers would b
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?group
 WHERE {

--- a/docs/api/rels/1/groupFoundedByAgent.md
+++ b/docs/api/rels/1/groupFoundedByAgent.md
@@ -21,7 +21,7 @@ From the record for Katherine Dreier, Man Ray or Marcel Duchamps, the group Soci
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?group
 WHERE {

--- a/docs/api/rels/1/groupFoundedByAgent.md
+++ b/docs/api/rels/1/groupFoundedByAgent.md
@@ -12,20 +12,33 @@ See the related [model documentation](/model/actor/#birth-and-death-formation-an
 
 From the record for Katherine Dreier, Man Ray or Marcel Duchamps, the group Societe Anonyme would be in the response
 
-
 ### Details
 
 * Class Given: Agent
 * Returns Class: Group
 * Relationship: foundedBy
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?group WHERE {
-   BIND (<%current%>AS ?who)
-.   ?group crm:P95i_was_formed_by ?formation .
-   ?formation crm:P14_carried_out_by ?who .
- }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?group
+WHERE {
+  {
+    ?group crm:P95i_was_formed_by ?activity .
+  } UNION {
+    ?activity crm:P95_has_formed ?group .
+  }
+  {
+    ?activity ccrm:P14_carried_out_by $current .
+  } UNION {
+    $current crm:P14i_performed ?activity .
+  }
+  {
+    $current a crm:E22_Person .
+  } UNION {
+    $current a crm:E74_Group .
+  }
+}
+```

--- a/docs/api/rels/1/groupFoundedByAgent.md
+++ b/docs/api/rels/1/groupFoundedByAgent.md
@@ -36,7 +36,7 @@ WHERE {
     $current crm:P14i_performed ?activity .
   }
   {
-    $current a crm:E22_Person .
+    $current a crm:E21_Person .
   } UNION {
     $current a crm:E74_Group .
   }

--- a/docs/api/rels/1/objectCarriesWork.md
+++ b/docs/api/rels/1/objectCarriesWork.md
@@ -12,16 +12,25 @@ See the related [model documentation](/model/document/#physical-objects-conceptu
 
 From the record for the Lord of the Rings, the record for the copy in the British Library would be in the response
 
-
 ### Details
 
 * Class Given: LinguisticObject
 * Returns Class: HumanMadeObject
 * Relationship: carries
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?object
+WHERE {
+  {
+    $current crm:P128_carries ?textualWork .
+  } UNION {
+    ?textualWork crm:P128i_is_carried_by $current .
+  }
+  ?textualWork a crm:E33_Linguistic_Object .
+  $current a crm:E22_Human-Made_Object .
+}
+```

--- a/docs/api/rels/1/objectCarriesWork.md
+++ b/docs/api/rels/1/objectCarriesWork.md
@@ -21,7 +21,7 @@ From the record for the Lord of the Rings, the record for the copy in the Britis
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectClassifiedAsConcept.md
+++ b/docs/api/rels/1/objectClassifiedAsConcept.md
@@ -21,7 +21,7 @@ From the record for Paintings, the record for Sunflowers would be in the respons
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectClassifiedAsConcept.md
+++ b/docs/api/rels/1/objectClassifiedAsConcept.md
@@ -12,16 +12,24 @@ See the related [model documentation](/model/base/#types-and-classifications)
 
 From the record for Paintings, the record for Sunflowers would be in the response
 
-
 ### Details
 
 * Class Given: Concept
 * Returns Class: HumanMadeObject
 * Relationship: classifiedAs
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?object
+WHERE {
+  {
+    $current crm:P2_has_type ?concept .
+  } UNION {
+    ?concept crm:P2_is_type_of $current .
+  }
+  $current a crm:E22_Human-Made_Object .
+}
+```

--- a/docs/api/rels/1/objectClassifiedAsConcept.md
+++ b/docs/api/rels/1/objectClassifiedAsConcept.md
@@ -28,7 +28,7 @@ WHERE {
   {
     $current crm:P2_has_type ?concept .
   } UNION {
-    ?concept crm:P2_is_type_of $current .
+    ?concept crm:P2i_is_type_of $current .
   }
   $current a crm:E22_Human-Made_Object .
 }

--- a/docs/api/rels/1/objectCuratedByAgent.md
+++ b/docs/api/rels/1/objectCuratedByAgent.md
@@ -21,7 +21,7 @@ From the record for the Paintings Department of the Rijksmuseum, the record for 
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectCuratedByAgent.md
+++ b/docs/api/rels/1/objectCuratedByAgent.md
@@ -12,25 +12,39 @@ See the related [model documentation](/model/object/ownership/#custody)
 
 From the record for the Paintings Department of the Rijksmuseum, the record for The Night Watch would be in the response.
 
-
 ### Details
 
 * Class Given: Agent
 * Returns Class: HumanMadeObject
 * Relationship: curatedBy
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?object WHERE {
-   BIND(<%current%> as ?who)
-   {
-     ?object a crm:E22_Human-Made_Object ; la:member_of ?coll .
-     ?coll crm:P16i_was_used_for ?curating .
-     ?curating crm:P14_carried_out_by ?who .
-    } UNION {
-     ?object crm:P50_has_current_keeper ?who .
-   }
+
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object la:member_of ?set .
+  } UNION {
+    ?set la:has_member ?object .
+  }
+  {
+    ?object crm:P50_has_current_keeper $current .
+  } UNION {
+    $current crm:P50i_is_current_keeper_of ?object .
+  }
+  {
+    ?set crm:P16i_was_used_for ?activity .
+  } UNION {
+    ?activity crm:P16_used_specific_object ?set .
+  }
+  {
+    ?activity crm:P14_was_carried_out_by $current .
+  } UNION {
+    $current crm:P14i_performed ?activity .
+  }
+  ?object a crm:E22_Human-Made_Object .
 }
 ```
-

--- a/docs/api/rels/1/objectCurrentPlace.md
+++ b/docs/api/rels/1/objectCurrentPlace.md
@@ -21,7 +21,7 @@ From the record for Getty's gallery W204, the record for Jeanne (Spring) would b
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectCurrentPlace.md
+++ b/docs/api/rels/1/objectCurrentPlace.md
@@ -12,18 +12,25 @@ See the related [model documentation](/model/object/ownership/#location)
 
 From the record for Getty's gallery W204, the record for Jeanne (Spring) would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: HumanMadeObject
 * Relationship: current
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?object WHERE {
-     BIND(<%current%> as ?where)
-     ?object a crm:E22_Human-Made_Object ;         crm:P55_has_current_location ?where }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object crm:P55_has_current_location $current .
+  } UNION {
+    $current crm:P55i_currently_holds ?object .
+  }
+  ?object a crm:E22_Human-Made_Object .
+  $current a crm:E53_Place .
+}
+```

--- a/docs/api/rels/1/objectDestructionCausedByActivity.md
+++ b/docs/api/rels/1/objectDestructionCausedByActivity.md
@@ -21,7 +21,7 @@ From the record for a fire that destroyed a museum, the record for an object des
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectDestructionCausedByActivity.md
+++ b/docs/api/rels/1/objectDestructionCausedByActivity.md
@@ -12,16 +12,24 @@ See the related [model documentation](/model/object/production/#cause-of-destruc
 
 From the record for a fire that destroyed a museum, the record for an object destroyed in the fire would be in the response
 
-
 ### Details
 
 * Class Given: Event,Activity
 * Returns Class: HumanMadeObject
 * Relationship: 
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object crm:P13i_was_destroyed_by $current .
+  } UNION {
+    $current crm:P13_destroyed ?object .
+  }
+  ?object a crm:E22_Human-Made_Object .
+}
+```

--- a/docs/api/rels/1/objectEncounteredAtPlace.md
+++ b/docs/api/rels/1/objectEncounteredAtPlace.md
@@ -12,19 +12,34 @@ See the related [model documentation](/model/object/production/#discovery-versus
 
 From the record for the Burgess Shale, the record for Anomalocaris Canadiensis would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: HumanMadeObject
 * Relationship: encounteredAt
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?object WHERE {
-     BIND(<%current%> as ?where)
-     ?object a crm:E22_Human-Made_Object ;         sci:O19i_was_object_found_by/crm:P9_consists_of*/crm:P7_took_place_at ?where .
+
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object sci:O19i_was_object_encountered_at ?encounter .
+  } UNION {
+    ?encounter sci:O19_encountered_object ?object .
   }
+  {
+    ?encounter crm:P9_consists_of*/crm:P7_took_place_at $current .
+  } UNION {
+    $current crm:P7i_witnessed/crm:P9i_forms_part_of* ?encounter .
+  }
+}
 ```
+
+> [!WARNING]
+> In CRMsci 3.0 `O19` is named:
+> > O19 encountered object (was object encountered through)
+> > -- <https://cidoc-crm.org/sites/default/files/CRMsci-v3.0i.i.i.pdf>
 

--- a/docs/api/rels/1/objectEncounteredAtPlace.md
+++ b/docs/api/rels/1/objectEncounteredAtPlace.md
@@ -21,7 +21,7 @@ From the record for the Burgess Shale, the record for Anomalocaris Canadiensis w
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectEncounteredByAgent.md
+++ b/docs/api/rels/1/objectEncounteredByAgent.md
@@ -12,20 +12,28 @@ See the related [model documentation](/model/object/production/#discovery-versus
 
 From the record for O.C. Marsh, the record for the Torosaurus holotype would be in the response
 
-
 ### Details
 
 * Class Given: Agent
 * Returns Class: HumanMadeObject
 * Relationship: encounteredBy
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?object WHERE {
-   BIND(<%current%> as ?who)
-   ?object a crm:E22_Human-Made_Object ; sci:O19i_was_object_encountered_at ?enc .
-   ?enc crm:P9_consists_of*/crm:P14_carried_out_by ?who .
-  }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object sci:O19i_was_object_encountered_at ?encounter .
+  } UNION {
+    ?encounter sci:O19_encountered_object ?object .
+  }
+  {
+    ?encounter (crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P14_carried_out_by $current .
+  } UNION {
+    $current crm:P14i_performed/(crm:P9_consists_of|crm:P9i_forms_part_of)* ?encounter .
+  }
+}
+```

--- a/docs/api/rels/1/objectEncounteredByAgent.md
+++ b/docs/api/rels/1/objectEncounteredByAgent.md
@@ -21,7 +21,7 @@ From the record for O.C. Marsh, the record for the Torosaurus holotype would be 
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectMadeOfMaterial.md
+++ b/docs/api/rels/1/objectMadeOfMaterial.md
@@ -21,7 +21,7 @@ From the record for Canvas, the record for The Night Watch would be in the respo
 ### SPARQL
 
 ```
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectMadeOfMaterial.md
+++ b/docs/api/rels/1/objectMadeOfMaterial.md
@@ -12,16 +12,24 @@ See the related [model documentation](/model/object/physical/#materials)
 
 From the record for Canvas, the record for The Night Watch would be in the response
 
-
 ### Details
 
 * Class Given: Material
 * Returns Class: HumanMadeObject
 * Relationship: madeOf
 
-
 ### SPARQL
-```
 
 ```
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object crm:P45_consists_of $current .
+  } UNION {
+    $current crm:P45i_is_incorporated_in ?object .
+  }
+  $current a crm:57_Material .
+}
+```

--- a/docs/api/rels/1/objectMemberOfSet.md
+++ b/docs/api/rels/1/objectMemberOfSet.md
@@ -21,8 +21,8 @@ From the record for the Rijksmuseum's highlight objects, the record for the Nigh
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX la: <https://linked.art/ns/terms/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX la: <https://linked.art/ns/terms/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectMemberOfSet.md
+++ b/docs/api/rels/1/objectMemberOfSet.md
@@ -12,16 +12,25 @@ See the related [model documentation](/model/collection/#features)
 
 From the record for the Rijksmuseum's highlight objects, the record for the Night Watch would be in the response
 
-
 ### Details
 
 * Class Given: Set
 * Returns Class: HumanMadeObject
 * Relationship: memberOf
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX la: <https://linked.art/ns/terms/> .
 
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object la:member_of $current .
+  } UNION {
+    $current la:has_member ?object .
+  }
+  $current a crm:E22_Human-Made_Object .
+}
+```

--- a/docs/api/rels/1/objectOwnedByAgent.md
+++ b/docs/api/rels/1/objectOwnedByAgent.md
@@ -21,7 +21,7 @@ From the record for the Rijksmuseum, the record for The Night Watch would be in 
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectOwnedByAgent.md
+++ b/docs/api/rels/1/objectOwnedByAgent.md
@@ -12,19 +12,23 @@ See the related [model documentation](/model/object/ownership/#ownership)
 
 From the record for the Rijksmuseum, the record for The Night Watch would be in the response.
 
-
 ### Details
 
 * Class Given: Agent
 * Returns Class: HumanMadeObject
 * Relationship: ownedBy
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?object WHERE {
-   BIND(<%current%> as ?who)
-   ?object a crm:E22_Human-Made_Object ; crm:P52_has_current_owner ?who .
- }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object crm:P52_has_current_owner $current .
+  } UNION {
+    $current crm:P52i_is_current_owner_of ?object .
+  }
+}
+```

--- a/docs/api/rels/1/objectPartOfObject.md
+++ b/docs/api/rels/1/objectPartOfObject.md
@@ -21,7 +21,7 @@ From the record for the Night Watch, the record for the frame of the Night Watch
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectPartOfObject.md
+++ b/docs/api/rels/1/objectPartOfObject.md
@@ -12,16 +12,24 @@ See the related [model documentation](/model/object/physical/#parts)
 
 From the record for the Night Watch, the record for the frame of the Night Watch would be in the response
 
-
 ### Details
 
 * Class Given: HumanMadeObject
 * Returns Class: HumanMadeObject
 * Relationship: objectPartOfObject
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object crm:P46i_forms_part_of $current .
+  } UNION {
+    $current crm:P46_is_composed_of ?object .
+  }
+  ?object a crm:E22_Human-Made_Object .
+}
+```

--- a/docs/api/rels/1/objectProducedAtPlace.md
+++ b/docs/api/rels/1/objectProducedAtPlace.md
@@ -12,19 +12,24 @@ See the related [model documentation](/model/object/production/#base-production-
 
 From the record for Amsterdam, the record for The Night Watch would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: HumanMadeObject
 * Relationship: producedAt
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?object WHERE {
-   BIND(<%current%> as ?where)
-   ?object a crm:E22_Human-Made_Object ;        crm:P108i_was_produced_by/crm:P9_consists_of*/crm:P7_took_place_at ?where .
-  }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object crm:P108i_was_produced_by/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P7_took_place_at $current .
+  } UNION {
+    $current crm:P7i_witnessed/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P108_has_produced ?object .
+  }
+  ?object a crm:E22_Human-Made_Object .
+}
+```

--- a/docs/api/rels/1/objectProducedAtPlace.md
+++ b/docs/api/rels/1/objectProducedAtPlace.md
@@ -21,7 +21,7 @@ From the record for Amsterdam, the record for The Night Watch would be in the re
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectProducedByAgent.md
+++ b/docs/api/rels/1/objectProducedByAgent.md
@@ -12,20 +12,23 @@ See the related [model documentation](/model/object/production/#base-production-
 
 From the record for Rembrandt, the record for The Night Watch would be in the response
 
-
 ### Details
 
 * Class Given: Agent
 * Returns Class: HumanMadeObject
 * Relationship: producedBy
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?object WHERE {
-   BIND(<%current%> as ?who)
-   ?object a crm:E22_Human-Made_Object ; crm:P108i_was_produced_by ?prod .
-   ?prod crm:P9_consists_of*/crm:P14_carried_out_by ?who .
-  }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object crm:P108i_was_produced_by/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P14_carried_out_by $current .
+  } UNION {
+    $current crm:P14i_performed/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P108_has_produced ?object .
+  }
+}
+```

--- a/docs/api/rels/1/objectProducedByAgent.md
+++ b/docs/api/rels/1/objectProducedByAgent.md
@@ -21,7 +21,7 @@ From the record for Rembrandt, the record for The Night Watch would be in the re
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectProductionCausedByActivity.md
+++ b/docs/api/rels/1/objectProductionCausedByActivity.md
@@ -12,16 +12,25 @@ See the related [model documentation](/model/object/production/#cause-of-product
 
 From the record for a commission activity, the record for the object that was produced because of the commission would be in the response
 
-
 ### Details
 
 * Class Given: Event,Activity
 * Returns Class: HumanMadeObject
 * Relationship: productionCausedBy
 
-
 ### SPARQL
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/> .
+
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object crm:P108i_was_produced_by/(crm:P9_consists_of|crm:P9i_forms_part_of)*/sci:O13i_is_triggered_by $current .
+  } UNION {
+    $current sci:O13_triggers/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P108_has_produced ?object .
+  }
+}
 ```
 

--- a/docs/api/rels/1/objectProductionCausedByActivity.md
+++ b/docs/api/rels/1/objectProductionCausedByActivity.md
@@ -21,8 +21,8 @@ From the record for a commission activity, the record for the object that was pr
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectProductionInfluencedByAgent.md
+++ b/docs/api/rels/1/objectProductionInfluencedByAgent.md
@@ -12,18 +12,29 @@ See the related [model documentation](/model/object/production/#inspirations-stu
 
 From the record for Albert Bierstadt, the prints of his works (which were not necessarily created by him) would be in the response
 
-
 ### Details
 
 * Class Given: Agent
 * Returns Class: HumanMadeObject
 * Relationship: productionInfluencedBy
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?objects WHERE {
-  ?objects crm:P108i_was_produced_by ?production .
-  ?production crm:P15_was_influenced_by <%current%>.  }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/> .
+
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object crm:P108i_was_produced_by/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P15_was_influenced_by $current .
+  } UNION {
+    $current crm:P15i_influenced/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P108_has_produced ?object .
+  }
+  {
+    $current a crm:E22_Person .
+  } UNION {
+    $current a crm:E74_Group .
+  }
+}
+```

--- a/docs/api/rels/1/objectProductionInfluencedByAgent.md
+++ b/docs/api/rels/1/objectProductionInfluencedByAgent.md
@@ -21,8 +21,8 @@ From the record for Albert Bierstadt, the prints of his works (which were not ne
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectProductionInfluencedByAgent.md
+++ b/docs/api/rels/1/objectProductionInfluencedByAgent.md
@@ -32,7 +32,7 @@ WHERE {
     $current crm:P15i_influenced/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P108_has_produced ?object .
   }
   {
-    $current a crm:E22_Person .
+    $current a crm:E21_Person .
   } UNION {
     $current a crm:E74_Group .
   }

--- a/docs/api/rels/1/objectProductionInfluencedByObject.md
+++ b/docs/api/rels/1/objectProductionInfluencedByObject.md
@@ -12,16 +12,25 @@ See the related [model documentation](/model/object/production/#inspirations-stu
 
 From the record a painting that was copied, the record for the copy would be in the response
 
-
 ### Details
 
 * Class Given: HumanMadeObject
 * Returns Class: HumanMadeObject
 * Relationship: productionInfluencedBy
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/> .
 
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object crm:P108i_was_produced_by/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P15_was_influenced_by $current .
+  } UNION {
+    $current crm:P15i_influenced/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P108_has_produced ?object .
+  }
+  $current a crm:E21_Human-Made_Object .
+}
+```

--- a/docs/api/rels/1/objectProductionInfluencedByObject.md
+++ b/docs/api/rels/1/objectProductionInfluencedByObject.md
@@ -31,6 +31,6 @@ WHERE {
   } UNION {
     $current crm:P15i_influenced/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P108_has_produced ?object .
   }
-  $current a crm:E21_Human-Made_Object .
+  $current a crm:E22_Human-Made_Object .
 }
 ```

--- a/docs/api/rels/1/objectProductionInfluencedByObject.md
+++ b/docs/api/rels/1/objectProductionInfluencedByObject.md
@@ -21,8 +21,8 @@ From the record a painting that was copied, the record for the copy would be in 
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectProductionInfluencedByPlace.md
+++ b/docs/api/rels/1/objectProductionInfluencedByPlace.md
@@ -19,9 +19,19 @@ See the related [model documentation](/model/object/production/#inspirations-stu
 * Returns Class: HumanMadeObject
 * Relationship: productionInfluencedBy
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/> .
 
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object crm:P108i_was_produced_by/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P15_was_influenced_by $current .
+  } UNION {
+    $current crm:P15i_influenced/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P108_has_produced ?object .
+  }
+  $current a crm:E53_Place .
+}
+```

--- a/docs/api/rels/1/objectProductionInfluencedByPlace.md
+++ b/docs/api/rels/1/objectProductionInfluencedByPlace.md
@@ -22,8 +22,8 @@ See the related [model documentation](/model/object/production/#inspirations-stu
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectProductionInfluencedByWork.md
+++ b/docs/api/rels/1/objectProductionInfluencedByWork.md
@@ -22,8 +22,8 @@ See the related [model documentation](/model/object/production/#inspirations-stu
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectProductionInfluencedByWork.md
+++ b/docs/api/rels/1/objectProductionInfluencedByWork.md
@@ -19,9 +19,23 @@ See the related [model documentation](/model/object/production/#inspirations-stu
 * Returns Class: HumanMadeObject
 * Relationship: productionInfluencedBy
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/> .
 
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object crm:P108i_was_produced_by/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P15_was_influenced_by $current .
+  } UNION {
+    $current crm:P15i_influenced/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P108_has_produced ?object .
+  }
+  {
+    $current a crm:E36_Visual_Item .
+  } UNION {
+    $current a crm:E33_Linguistic_Object .
+  }
+}
+```

--- a/docs/api/rels/1/objectProductionTechniqueConcept.md
+++ b/docs/api/rels/1/objectProductionTechniqueConcept.md
@@ -21,7 +21,7 @@ From the record for Bronze Casting, the record for The Thinker would be in the r
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectProductionTechniqueConcept.md
+++ b/docs/api/rels/1/objectProductionTechniqueConcept.md
@@ -12,16 +12,23 @@ See the related [model documentation](/model/object/production/#techniques-and-c
 
 From the record for Bronze Casting, the record for The Thinker would be in the response 
 
-
 ### Details
 
 * Class Given: Concept
 * Returns Class: HumanMadeObject
 * Relationship: productionTechnique
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object crm:P108i_was_produced_by/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P32_used_general_technique $current .
+  } UNION {
+    $current crm:P32i_was_technique_of/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P108_has_produced ?object .
+  }
+}
+```

--- a/docs/api/rels/1/objectShowsWork.md
+++ b/docs/api/rels/1/objectShowsWork.md
@@ -21,7 +21,7 @@ From the record for the image of the Night Watch, the record for the painting wo
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/objectShowsWork.md
+++ b/docs/api/rels/1/objectShowsWork.md
@@ -12,16 +12,23 @@ See the related [model documentation](/model/object/aboutness/#physical-object-a
 
 From the record for the image of the Night Watch, the record for the painting would be in the response
 
-
 ### Details
 
 * Class Given: VisualItem
 * Returns Class: HumanMadeObject
 * Relationship: shows
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?object crm:P65_shows_visual_item $current .
+  } UNION {
+    $current crm:P65i_is_shown_by ?object .
+  }
+}
+```

--- a/docs/api/rels/1/personActiveAtPlace.md
+++ b/docs/api/rels/1/personActiveAtPlace.md
@@ -12,16 +12,29 @@ See the related [model documentation](/model/actor/#active-dates)
 
 From the record for Arles France, the record for Vincent Van Gogh would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Person
 * Relationship: activeAt
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?person
+WHERE {
+  {
+    ?person crm:P14i_performed/(crm:P9_consists_of|crm:P9i_forms_part_of)* ?activity .
+  } UNION {
+    ?activity (crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P14_carried_out_by ?person .
+  }
+  {
+    ?activity crm:P7_took_place_at $current .
+  } UNION {
+    $current crm:P7i_witnessed ?activity .
+  }
+  ?person a crm:E21_Person .
+}
+```

--- a/docs/api/rels/1/personActiveAtPlace.md
+++ b/docs/api/rels/1/personActiveAtPlace.md
@@ -21,7 +21,7 @@ From the record for Arles France, the record for Vincent Van Gogh would be in th
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?person
 WHERE {

--- a/docs/api/rels/1/personBornAtPlace.md
+++ b/docs/api/rels/1/personBornAtPlace.md
@@ -22,7 +22,7 @@ From the record for Leiden, the record for Rembrandt would be in the response
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?person
 WHERE {

--- a/docs/api/rels/1/personBornAtPlace.md
+++ b/docs/api/rels/1/personBornAtPlace.md
@@ -12,7 +12,6 @@ See the related [model documentation](/model/actor/#birth-and-death-formation-an
 
 From the record for Leiden, the record for Rembrandt would be in the response
 
-
 ### Details
 
 * Class Given: Place
@@ -21,11 +20,21 @@ From the record for Leiden, the record for Rembrandt would be in the response
 
 
 ### SPARQL
-```
-SELECT DISTINCT ?agent WHERE {
-   BIND(<%current%>as ?where)
-   ?agent crm:P98i_was_born ?birth .
-    ?birth crm:P7_took_place_at ?where .
- }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?person
+WHERE {
+  {
+    ?person crm:P98i_was_born ?birth .
+  } UNION {
+    ?birth crm:P98_brought_into_life ?person .
+  }
+  {
+   ?birth crm:P7_took_place_at $current .
+  } UNION {
+   $current crm:P7i_witnessed ?birth .
+  }
+}
+```

--- a/docs/api/rels/1/personDeathCausedByActivity.md
+++ b/docs/api/rels/1/personDeathCausedByActivity.md
@@ -21,7 +21,7 @@ From the record for the Bubonic Plague, the record for a person who died of the 
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?person
 WHERE {

--- a/docs/api/rels/1/personDeathCausedByActivity.md
+++ b/docs/api/rels/1/personDeathCausedByActivity.md
@@ -12,16 +12,28 @@ See the related [model documentation]()
 
 From the record for the Bubonic Plague, the record for a person who died of the plague would be in the response
 
-
 ### Details
 
 * Class Given: Event,Activity
 * Returns Class: Person
 * Relationship: 
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?person
+WHERE {
+  {
+    ?person crm:P100i_died_in ?death .
+  } UNION {
+    ?death crm:P100_was_death_of ?person .
+  }
+  {
+    ?death sci:O13i_is_triggered_by $current .
+  } UNION {
+    $current sci:O13_triggered ?death .
+  }
+}
+```

--- a/docs/api/rels/1/personDiedAtPlace.md
+++ b/docs/api/rels/1/personDiedAtPlace.md
@@ -21,7 +21,7 @@ From the record for Amsterdam, the record for Rembrandt would be in the response
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?person
 WHERE {

--- a/docs/api/rels/1/personDiedAtPlace.md
+++ b/docs/api/rels/1/personDiedAtPlace.md
@@ -12,20 +12,28 @@ See the related [model documentation](/model/actor/#birth-and-death-formation-an
 
 From the record for Amsterdam, the record for Rembrandt would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Person
 * Relationship: diedAt
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?person WHERE {
-   BIND(<%current%>as ?where)
-   ?person crm:P100i_died_in ?death .
-    ?death crm:P7_took_place_at ?where .
- }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?person
+WHERE {
+  {
+    ?person crm:P100i_died_in ?death .
+  } UNION {
+    ?death crm:P100_was_death_of ?person .
+  }
+  {
+    ?death crm:P7_took_place_at $current .
+  } UNION {
+    $current crm:P7i_witnessed ?death .
+  }
+}
+```

--- a/docs/api/rels/1/placeClassifiedAsConcept.md
+++ b/docs/api/rels/1/placeClassifiedAsConcept.md
@@ -21,7 +21,7 @@ From the record for the concept of Cities, the record for Amsterdam would be in 
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?place
 WHERE {

--- a/docs/api/rels/1/placeClassifiedAsConcept.md
+++ b/docs/api/rels/1/placeClassifiedAsConcept.md
@@ -12,16 +12,24 @@ See the related [model documentation](/model/base/#types-and-classifications)
 
 From the record for the concept of Cities, the record for Amsterdam would be in the response
 
-
 ### Details
 
 * Class Given: Concept
 * Returns Class: Place
 * Relationship: classifiedAs
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?place
+WHERE {
+  {
+    ?place crm:P2_has_type $current .
+  } UNION {
+    $current crm:P2i_is_type_of ?place .
+  }
+  ?place a crm:E53_Place .
+}
+```

--- a/docs/api/rels/1/placeMemberOfSet.md
+++ b/docs/api/rels/1/placeMemberOfSet.md
@@ -12,16 +12,25 @@ See the related [model documentation](/model/collection/#features)
 
 From the record for the set of places in which Van Gogh lived, the record for Arles would be in the response
 
-
 ### Details
 
 * Class Given: Set
 * Returns Class: Place
 * Relationship: memberOf
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX la: <https://linked.art/ns/terms/> .
 
+SELECT DISTINCT ?place
+WHERE {
+  {
+    ?place la:member_of $current .
+  } UNION {
+    $current la:has_member ?place .
+  }
+  $current a crm:E53_Place .
+}
+```

--- a/docs/api/rels/1/placeMemberOfSet.md
+++ b/docs/api/rels/1/placeMemberOfSet.md
@@ -21,8 +21,8 @@ From the record for the set of places in which Van Gogh lived, the record for Ar
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX la: <https://linked.art/ns/terms/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX la: <https://linked.art/ns/terms/>
 
 SELECT DISTINCT ?place
 WHERE {

--- a/docs/api/rels/1/placePartOfPlace.md
+++ b/docs/api/rels/1/placePartOfPlace.md
@@ -21,7 +21,7 @@ From the record for Île-de-France, the record for Paris would be in the respons
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?place
 WHERE {

--- a/docs/api/rels/1/placePartOfPlace.md
+++ b/docs/api/rels/1/placePartOfPlace.md
@@ -12,16 +12,24 @@ See the related [model documentation](/model/place/#core-information)
 
 From the record for Île-de-France, the record for Paris would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Place
 * Relationship: partOf
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?place
+WHERE {
+  {
+    ?place crm:P89_falls_within $current .
+  } UNION {
+    $current crm:P89i_contains ?place .
+  }
+  ?place a crm:E53_Place .
+}
+```

--- a/docs/api/rels/1/setClassifiedAsConcept.md
+++ b/docs/api/rels/1/setClassifiedAsConcept.md
@@ -21,7 +21,18 @@ From the record for the concept of Auction Lots, the record for Lot 14 would be 
 
 
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX la: <https://linked.art/ns/terms/> .
 
+SELECT DISTINCT ?set
+WHERE {
+  {
+    ?set crm:P2_has_type $current .
+  } UNION {
+    $current crm:P2i_is_type_of ?set .
+  }
+  ?set a la:Set .
+}
+```

--- a/docs/api/rels/1/setClassifiedAsConcept.md
+++ b/docs/api/rels/1/setClassifiedAsConcept.md
@@ -23,8 +23,8 @@ From the record for the concept of Auction Lots, the record for Lot 14 would be 
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX la: <https://linked.art/ns/terms/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX la: <https://linked.art/ns/terms/>
 
 SELECT DISTINCT ?set
 WHERE {

--- a/docs/api/rels/1/setCreatedAtPlace.md
+++ b/docs/api/rels/1/setCreatedAtPlace.md
@@ -12,16 +12,32 @@ See the related [model documentation](/model/collection/#features)
 
 From the record for New Haven, the record for the set representing the Archives of O. C. Marsh would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Set
 * Relationship: createdAt
 
-
 ### SPARQL
+
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX la: <https://linked.art/ns/terms/> .
+
+SELECT DISTINCT ?set
+WHERE {
+  {
+    ?set crm:P94i_was_created_by ?activity .
+  } UNION {
+    ?activity crm:P94_has_created ?set .
+  }
+  {
+    ?activity crm:P7_took_place_at $current .
+  } UNION {
+    $current crm:P7i_witnessed ?activity .
+  }
+  ?set a la:Set .
+}
 ```
 
-```
 

--- a/docs/api/rels/1/setCreatedAtPlace.md
+++ b/docs/api/rels/1/setCreatedAtPlace.md
@@ -21,8 +21,8 @@ From the record for New Haven, the record for the set representing the Archives 
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX la: <https://linked.art/ns/terms/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX la: <https://linked.art/ns/terms/>
 
 SELECT DISTINCT ?set
 WHERE {

--- a/docs/api/rels/1/setCreatedByAgent.md
+++ b/docs/api/rels/1/setCreatedByAgent.md
@@ -19,11 +19,29 @@ From the record for O.C. Marsh, the record for his archive would be in the respo
 * Returns Class: Set
 * Relationship: createdBy
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?set WHERE {
-   ?set crm:P94i_was_created_by ?creation .
-    ?creation crm:P15_was_influenced_by <%current%>. }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX la: <https://linked.art/ns/terms/> .
+
+SELECT DISTINCT ?set
+WHERE {
+  {
+    ?set crm:P94i_was_created_by ?activity .
+  } UNION {
+    ?activity crm:P94_has_created ?set .
+  }
+  {
+    ?activity crm:P15_was_influenced_by $current .
+  } UNION {
+    $current crm:P15i_influenced ?activity .
+  }
+  {
+    $current a crm:E22_Person .
+  } UNION {
+    $current a crm:E76_Group .
+  }
+  ?set a la:Set .
+}
+```

--- a/docs/api/rels/1/setCreatedByAgent.md
+++ b/docs/api/rels/1/setCreatedByAgent.md
@@ -22,8 +22,8 @@ From the record for O.C. Marsh, the record for his archive would be in the respo
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX la: <https://linked.art/ns/terms/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX la: <https://linked.art/ns/terms/>
 
 SELECT DISTINCT ?set
 WHERE {

--- a/docs/api/rels/1/setCreatedByAgent.md
+++ b/docs/api/rels/1/setCreatedByAgent.md
@@ -38,7 +38,7 @@ WHERE {
     $current crm:P15i_influenced ?activity .
   }
   {
-    $current a crm:E22_Person .
+    $current a crm:E21_Person .
   } UNION {
     $current a crm:E76_Group .
   }

--- a/docs/api/rels/1/setCreationCausedByActivity.md
+++ b/docs/api/rels/1/setCreationCausedByActivity.md
@@ -21,7 +21,19 @@ See the related [model documentation]()
 
 
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX la: <https://linked.art/ns/terms/> .
+PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/> .
 
+SELECT DISTINCT ?object
+WHERE {
+  {
+    ?set crm:P94i_was_created_by/(crm:P9_consists_of|crm:P9i_forms_part_of)*/sci:O13i_is_triggered_by ?activity .
+  } UNION {
+    ?activity sci:O13_triggers/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P94_has_created ?set .
+  }
+  ?set a la:Set .
+}
+```

--- a/docs/api/rels/1/setCreationCausedByActivity.md
+++ b/docs/api/rels/1/setCreationCausedByActivity.md
@@ -23,9 +23,9 @@ See the related [model documentation]()
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX la: <https://linked.art/ns/terms/> .
-PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX la: <https://linked.art/ns/terms/>
+PREFIX sci: <http://www.ics.forth.gr/isl/CRMsci/>
 
 SELECT DISTINCT ?object
 WHERE {

--- a/docs/api/rels/1/setMemberOfSet.md
+++ b/docs/api/rels/1/setMemberOfSet.md
@@ -21,7 +21,7 @@ From the record for the set for the Archives of O. C. Marsh, the record for Seri
 ### SPARQL
 
 ```sparql
-PREFIX la: <https://linked.art/ns/terms/> .
+PREFIX la: <https://linked.art/ns/terms/>
 
 SELECT DISTINCT ?set
 WHERE {

--- a/docs/api/rels/1/setMemberOfSet.md
+++ b/docs/api/rels/1/setMemberOfSet.md
@@ -12,16 +12,24 @@ See the related [model documentation](/model/collection/#features)
 
 From the record for the set for the Archives of O. C. Marsh, the record for Series 1 within that archive would be in the response
 
-
 ### Details
 
 * Class Given: Set
 * Returns Class: Set
 * Relationship: memberOf
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX la: <https://linked.art/ns/terms/> .
 
+SELECT DISTINCT ?set
+WHERE {
+  {
+    ?set la:member_of $current .
+  } UNION {
+    $current la:has_member ?set .
+  }
+  $current a la:Set .
+}
+```

--- a/docs/api/rels/1/temporalMemberOfSet.md
+++ b/docs/api/rels/1/temporalMemberOfSet.md
@@ -12,16 +12,32 @@ See the related [model documentation](/model/collection/#features)
 
 From the record for the set of Linked Art face to face meetings, the record for the second face to face meeting in Oxford would be in the response
 
-
 ### Details
 
 * Class Given: Set
 * Returns Class: Temporal
 * Relationship: memberOf
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX la: <https://linked.art/ns/terms/> .
 
+SELECT DISTINCT ?temporal
+WHERE {
+  {
+    ?temporal la:member_of $current .
+  } UNION {
+    $current la:has_member ?temporal .
+  }
+  {
+    ?temporal a crm:E4_Period .
+  } UNION {
+    ?temporal a crm:E5_Event .
+  } UNION {
+    ?temporal a crm:E7_Activity .
+  }
+  $current a la:Set .
+}
+```

--- a/docs/api/rels/1/temporalMemberOfSet.md
+++ b/docs/api/rels/1/temporalMemberOfSet.md
@@ -21,8 +21,8 @@ From the record for the set of Linked Art face to face meetings, the record for 
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX la: <https://linked.art/ns/terms/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX la: <https://linked.art/ns/terms/>
 
 SELECT DISTINCT ?temporal
 WHERE {

--- a/docs/api/rels/1/workAboutActivity.md
+++ b/docs/api/rels/1/workAboutActivity.md
@@ -12,16 +12,35 @@ See the related [model documentation](/model/object/aboutness/#subject)
 
 From the record for the Bronze Age, the record for a work about the Bronze Age would be in the response
 
-
 ### Details
 
 * Class Given: Temporal
 * Returns Class: Work
 * Relationship: 
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    $current crm:P129_is_about ?work .
+  } UNION {
+    ?work crm:P129i_is_subject_of $current .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  {
+    $current a crm:E4_Period .
+  } UNION {
+    $current a crm:E5_Event .
+  } UNION {
+    $current a crm:E7_Activity .
+  }
+}
+```

--- a/docs/api/rels/1/workAboutActivity.md
+++ b/docs/api/rels/1/workAboutActivity.md
@@ -21,7 +21,7 @@ From the record for the Bronze Age, the record for a work about the Bronze Age w
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workAboutAgent.md
+++ b/docs/api/rels/1/workAboutAgent.md
@@ -21,10 +21,26 @@ From the record for Abraham Lincoln, the record for We are Lincoln Men : Abraham
 
 
 ### SPARQL
-```
-SELECT DISTINCT ?work WHERE {
-    BIND(<%current%> AS ?who)
-    ?work crm:P129_is_about ?who .
- } 
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P129_is_about $current .
+  } UNION {
+    $current crm:P129i_is_subject_of ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  {
+    $current a crm:E22_Person .
+  } UNION {
+    $current a crm:E76_Group .
+  }
+}
+```

--- a/docs/api/rels/1/workAboutAgent.md
+++ b/docs/api/rels/1/workAboutAgent.md
@@ -38,7 +38,7 @@ WHERE {
     ?work a crm:E36_Visual_Item .
   }
   {
-    $current a crm:E22_Person .
+    $current a crm:E21_Person .
   } UNION {
     $current a crm:E76_Group .
   }

--- a/docs/api/rels/1/workAboutAgent.md
+++ b/docs/api/rels/1/workAboutAgent.md
@@ -23,7 +23,7 @@ From the record for Abraham Lincoln, the record for We are Lincoln Men : Abraham
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workAboutConcept.md
+++ b/docs/api/rels/1/workAboutConcept.md
@@ -12,16 +12,29 @@ See the related [model documentation](/model/object/aboutness/#subject)
 
 From the record for the concept of Democracy, the record for Diamond's work "In Search of Democracy" would be in the response
 
-
 ### Details
 
 * Class Given: Concept
 * Returns Class: Work
 * Relationship: about
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P129_is_about $current .
+  } UNION {
+    $current crm:P129i_is_subject_of ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  $current a crm:E55_Type .
+}
+```

--- a/docs/api/rels/1/workAboutConcept.md
+++ b/docs/api/rels/1/workAboutConcept.md
@@ -21,7 +21,7 @@ From the record for the concept of Democracy, the record for Diamond's work "In 
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workAboutObject.md
+++ b/docs/api/rels/1/workAboutObject.md
@@ -35,6 +35,6 @@ WHERE {
   } UNION {
     ?work a crm:E36_Visual_Item .
   }
-  $current a crm:E21_Human-Made_Object .
+  $current a crm:E22_Human-Made_Object .
 }
 ```

--- a/docs/api/rels/1/workAboutObject.md
+++ b/docs/api/rels/1/workAboutObject.md
@@ -21,7 +21,7 @@ From the record for the Night Watch, the record for Bikker's "The Night Watch" w
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workAboutObject.md
+++ b/docs/api/rels/1/workAboutObject.md
@@ -12,16 +12,29 @@ See the related [model documentation](/model/object/aboutness/#subject)
 
 From the record for the Night Watch, the record for Bikker's "The Night Watch" would be in the response
 
-
 ### Details
 
 * Class Given: HumanMadeObject
 * Returns Class: Work
 * Relationship: about
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P129_is_about $current .
+  } UNION {
+    $current crm:P129i_is_subject_of ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  $current a crm:E21_Human-Made_Object .
+}
+```

--- a/docs/api/rels/1/workAboutOrRepresentsActivity.md
+++ b/docs/api/rels/1/workAboutOrRepresentsActivity.md
@@ -12,16 +12,35 @@ See the related [model documentation](/model/object/aboutness/#subject)
 
 From the record for the activity of the Battle of Bunker Hill, the records for the text of an article about it and the image of Trumbull's painting would both be in the response
 
-
 ### Details
 
 * Class Given: Temporal
 * Returns Class: Work
 * Relationship: 
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P129_is_about|crm:P138_represents $current .
+  } UNION {
+    $current crm:P129i_is_subject_of|crm:P138i_has_representation ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  {
+    $current a crm:E4_Period .
+  } UNION {
+    $current a crm:E5_Event .
+  } UNION {
+    $current a crm:E7_Activity .
+  }
+}
+```

--- a/docs/api/rels/1/workAboutOrRepresentsActivity.md
+++ b/docs/api/rels/1/workAboutOrRepresentsActivity.md
@@ -21,7 +21,7 @@ From the record for the activity of the Battle of Bunker Hill, the records for t
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workAboutOrRepresentsAgent.md
+++ b/docs/api/rels/1/workAboutOrRepresentsAgent.md
@@ -21,7 +21,7 @@ From the record for John Trumbull, the visual items and texts that depict him (s
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workAboutOrRepresentsAgent.md
+++ b/docs/api/rels/1/workAboutOrRepresentsAgent.md
@@ -36,7 +36,7 @@ WHERE {
     ?work a crm:E36_Visual_Item .
   }
   {
-    $current a crm:E22_Person .
+    $current a crm:E21_Person .
   } UNION {
     $current a crm:E76_Group .
   }

--- a/docs/api/rels/1/workAboutOrRepresentsAgent.md
+++ b/docs/api/rels/1/workAboutOrRepresentsAgent.md
@@ -12,20 +12,33 @@ See the related [model documentation](/model/object/aboutness/#subject)
 
 From the record for John Trumbull, the visual items and texts that depict him (such as a bibliographic record and a self-portrait) would be in the response
 
-
 ### Details
 
 * Class Given: Agent
 * Returns Class: Work
 * Relationship: about / represents
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?work WHERE {
-   {
-     ?work crm:P138_represents <%current%>.   }   UNION   {
-     ?work crm:P129_is_about <%current%>.   }
+
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P129_is_about|crm:P138_represents $current .
+  } UNION {
+    $current crm:P129i_is_subject_of|crm:P138i_has_representation ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  {
+    $current a crm:E22_Person .
+  } UNION {
+    $current a crm:E76_Group .
+  }
 }
 ```
-

--- a/docs/api/rels/1/workAboutOrRepresentsConcept.md
+++ b/docs/api/rels/1/workAboutOrRepresentsConcept.md
@@ -21,7 +21,7 @@ From the record for the concept of Law and Order, the record for the work of the
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workAboutOrRepresentsConcept.md
+++ b/docs/api/rels/1/workAboutOrRepresentsConcept.md
@@ -12,16 +12,29 @@ See the related [model documentation](/model/object/aboutness/#subject)
 
 From the record for the concept of Law and Order, the record for the work of the Night Watch would be in the response
 
-
 ### Details
 
 * Class Given: Concept
 * Returns Class: Concept
 * Relationship: about / represents
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P129_is_about|crm:P138_represents $current .
+  } UNION {
+    $current crm:P129i_is_subject_of|crm:P138i_has_representation ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  $current a crm:E55_Type .
+}
+```

--- a/docs/api/rels/1/workAboutOrRepresentsObject.md
+++ b/docs/api/rels/1/workAboutOrRepresentsObject.md
@@ -22,7 +22,7 @@ See the related [model documentation](/model/object/aboutness/#subject)
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workAboutOrRepresentsObject.md
+++ b/docs/api/rels/1/workAboutOrRepresentsObject.md
@@ -19,9 +19,23 @@ See the related [model documentation](/model/object/aboutness/#subject)
 * Returns Class: Work
 * Relationship: about / represents
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P129_is_about|crm:P138_represents $current .
+  } UNION {
+    $current crm:P129i_is_subject_of|crm:P138i_has_representation ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  $current a crm:E22_Human-Made_Object .
+}
+```

--- a/docs/api/rels/1/workAboutOrRepresentsPlace.md
+++ b/docs/api/rels/1/workAboutOrRepresentsPlace.md
@@ -22,7 +22,7 @@ From the record for Paris, the records for the image carried by a painting of No
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workAboutOrRepresentsPlace.md
+++ b/docs/api/rels/1/workAboutOrRepresentsPlace.md
@@ -12,7 +12,6 @@ See the related [model documentation](/model/object/aboutness/#subject)
 
 From the record for Paris, the records for the image carried by a painting of Notre Dame and the text of a book about the city would be in the response
 
-
 ### Details
 
 * Class Given: Place
@@ -21,7 +20,22 @@ From the record for Paris, the records for the image carried by a painting of No
 
 
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P129_is_about|crm:P138_represents $current .
+  } UNION {
+    $current crm:P129i_is_subject_of|crm:P138i_has_representation ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  $current a crm:E53_Place .
+}
+```

--- a/docs/api/rels/1/workAboutOrRepresentsSet.md
+++ b/docs/api/rels/1/workAboutOrRepresentsSet.md
@@ -21,8 +21,8 @@ From the record for the set for the Archives of O. C. Marsh, the records for an 
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX la: <https://linked.art/ns/terms/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX la: <https://linked.art/ns/terms/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workAboutOrRepresentsSet.md
+++ b/docs/api/rels/1/workAboutOrRepresentsSet.md
@@ -12,16 +12,30 @@ See the related [model documentation](/model/object/aboutness/#subject)
 
 From the record for the set for the Archives of O. C. Marsh, the records for an article about the archive and an image of the archive would be in the response
 
-
 ### Details
 
 * Class Given: Set
 * Returns Class: Work
 * Relationship: about / represents
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX la: <https://linked.art/ns/terms/> .
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P129_is_about|crm:P138_represents $current .
+  } UNION {
+    $current crm:P129i_is_subject_of|crm:P138i_has_representation ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  $current a la:Set .
+}
+```

--- a/docs/api/rels/1/workAboutOrRepresentsWork.md
+++ b/docs/api/rels/1/workAboutOrRepresentsWork.md
@@ -21,8 +21,8 @@ See the related [model documentation](/model/object/aboutness/#subject)
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX la: <https://linked.art/ns/terms/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX la: <https://linked.art/ns/terms/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workAboutOrRepresentsWork.md
+++ b/docs/api/rels/1/workAboutOrRepresentsWork.md
@@ -18,9 +18,28 @@ See the related [model documentation](/model/object/aboutness/#subject)
 * Returns Class: Work
 * Relationship: about / represents
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX la: <https://linked.art/ns/terms/> .
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P129_is_about|crm:P138_represents $current .
+  } UNION {
+    $current crm:P129i_is_subject_of|crm:P138i_has_representation ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  {
+    $current a crm:E33_Linguistic_Object .
+  } UNION {
+    $current a crm:E36_Visual_Item .
+  }
+}
+```

--- a/docs/api/rels/1/workAboutPlace.md
+++ b/docs/api/rels/1/workAboutPlace.md
@@ -21,7 +21,7 @@ From the record for Paris France, the record for Victor Hugo's work "Paris" woul
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workAboutPlace.md
+++ b/docs/api/rels/1/workAboutPlace.md
@@ -12,19 +12,29 @@ See the related [model documentation](/model/object/aboutness/#subject)
 
 From the record for Paris France, the record for Victor Hugo's work "Paris" would be in the response 
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Work
 * Relationship: about
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?work WHERE {
-   BIND(<%current%>as ?where)
-   ?work crm:P129_is_about ?where .
-  }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P129_is_about $current .
+  } UNION {
+    $current crm:P129i_is_subject_of ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  $current a crm:E53_Place .
+}
+```

--- a/docs/api/rels/1/workAboutSet.md
+++ b/docs/api/rels/1/workAboutSet.md
@@ -21,8 +21,8 @@ From the record for the set for the Archives of O. C. Marsh, a text of an articl
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX la: <https://linked.art/ns/terms/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX la: <https://linked.art/ns/terms/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workAboutSet.md
+++ b/docs/api/rels/1/workAboutSet.md
@@ -12,16 +12,30 @@ See the related [model documentation](/model/object/aboutness/#subject)
 
 From the record for the set for the Archives of O. C. Marsh, a text of an article about the archives would be in the response
 
-
 ### Details
 
 * Class Given: Set
 * Returns Class: Work
 * Relationship: about
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX la: <https://linked.art/ns/terms/> .
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P129_is_about $current .
+  } UNION {
+    $current crm:P129i_is_subject_of ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  $current a la:Set .
+}
+```

--- a/docs/api/rels/1/workAboutWork.md
+++ b/docs/api/rels/1/workAboutWork.md
@@ -12,16 +12,33 @@ See the related [model documentation](/model/object/aboutness/#subject)
 
 From the record for The Lord of the Rings, the record for an article about Tolkien's work would be in the response
 
-
 ### Details
 
 * Class Given: Work
 * Returns Class: Work
 * Relationship: about
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P129_is_about $current .
+  } UNION {
+    $current crm:P129i_is_subject_of ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  {
+    $current a crm:E33_Linguistic_Object .
+  } UNION {
+    $current a crm:E36_Visual_Item .
+  }
+}
+```

--- a/docs/api/rels/1/workAboutWork.md
+++ b/docs/api/rels/1/workAboutWork.md
@@ -21,7 +21,7 @@ From the record for The Lord of the Rings, the record for an article about Tolki
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workClassifiedAsConcept.md
+++ b/docs/api/rels/1/workClassifiedAsConcept.md
@@ -21,8 +21,8 @@ From the record for Impressionism, the record for the work of Van Gogh's "Irises
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-PREFIX la: <https://linked.art/ns/terms/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX la: <https://linked.art/ns/terms/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workClassifiedAsConcept.md
+++ b/docs/api/rels/1/workClassifiedAsConcept.md
@@ -12,16 +12,29 @@ See the related [model documentation](/model/base/#types-and-classifications)
 
 From the record for Impressionism, the record for the work of Van Gogh's "Irises" would be in the response
 
-
 ### Details
 
 * Class Given: Concept
 * Returns Class: Work
 * Relationship: classifiedAs
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX la: <https://linked.art/ns/terms/> .
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P2_has_type $current .
+  } UNION {
+    $current crm:P2i_is_type_of ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+}
+```

--- a/docs/api/rels/1/workCreatedAtPlace.md
+++ b/docs/api/rels/1/workCreatedAtPlace.md
@@ -12,19 +12,29 @@ See the related [model documentation](/model/document/#creation-and-publication)
 
 From the record for Oxford UK, the Lord of the Rings and the Hobbit would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Work
 * Relationship: createdAt
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?work WHERE {
-   BIND(<%current%> as ?where)
-   ?work crm:P94i_was_created_by/crm:P9_consists_of*/crm:P7_took_place_at ?where .
-  }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P94i_was_created_by/crm:P9_consists_of*/crm:P7_took_place_at $current .
+  } UNION {
+    $current crm:P7i_witnessed/crm:P9i_forms_part_of*/crm:P94_has_created ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  $current a crm:E53_Place .
+}
+```

--- a/docs/api/rels/1/workCreatedAtPlace.md
+++ b/docs/api/rels/1/workCreatedAtPlace.md
@@ -21,7 +21,7 @@ From the record for Oxford UK, the Lord of the Rings and the Hobbit would be in 
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workCreatedByAgent.md
+++ b/docs/api/rels/1/workCreatedByAgent.md
@@ -21,7 +21,7 @@ From the record for André Chastel, the record for The Vatican Frescoes of Miche
 ### SPARQL
 
 ```sparql
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
 SELECT DISTINCT ?work
 WHERE {

--- a/docs/api/rels/1/workCreatedByAgent.md
+++ b/docs/api/rels/1/workCreatedByAgent.md
@@ -36,7 +36,7 @@ WHERE {
     ?work a crm:E36_Visual_Item .
   }
   {
-    $current a crm:E22_Person .
+    $current a crm:E21_Person .
   } UNION {
     $current a crm:E76_Group .
   }

--- a/docs/api/rels/1/workCreatedByAgent.md
+++ b/docs/api/rels/1/workCreatedByAgent.md
@@ -12,20 +12,33 @@ See the related [model documentation](/model/document/#creation-and-publication)
 
 From the record for André Chastel, the record for The Vatican Frescoes of Michelangelo would be in the response.
 
-
 ### Details
 
 * Class Given: Agent
 * Returns Class: Work
 * Relationship: createdBy
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?work WHERE {
-   BIND(<%current%> as ?who)
-     ?work crm:P94i_was_created_by ?cre .
-         ?cre crm:P9_consists_of*/crm:P14_carried_out_by ?who .
- }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P94i_was_created_by/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P14_carried_out_by $current .
+  } UNION {
+    $current crm:P7i_witnessed/(crm:P9i_forms_part_of|crm:P9_consists_of)*/crm:P14i_performed ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  {
+    $current a crm:E22_Person .
+  } UNION {
+    $current a crm:E76_Group .
+  }
+}
+```

--- a/docs/api/rels/1/workCreationCausedByActivity.md
+++ b/docs/api/rels/1/workCreationCausedByActivity.md
@@ -21,7 +21,26 @@ From the record for a conference activity, the record for the proceedings of the
 
 
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P94i_was_created_by/(crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P14_carried_out_by $current .
+  } UNION {
+    $current crm:P7i_witnessed/(crm:P9i_forms_part_of|crm:P9_consists_of)*/crm:P14i_performed ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  {
+    $current a crm:E21_Person .
+  } UNION {
+    $current a crm:E76_Group .
+  }
+}
+```

--- a/docs/api/rels/1/workCreationTechniqueConcept.md
+++ b/docs/api/rels/1/workCreationTechniqueConcept.md
@@ -12,16 +12,29 @@ See the related [model documentation]()
 
 From the record for Sculpting, the record for the sculpture "Bather putting up her hair" would be in the response
 
-
 ### Details
 
 * Class Given: Concept
 * Returns Class: Work
 * Relationship: creationTechnique
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P94i_was_created_by/(crm:P9_consists_of|crm:P9i_forms_part_of)*/sci:O13i_is_triggered_by $current .
+  } UNION {
+    $current crm:P7i_witnessed/(crm:P9i_forms_part_of|crm:P9_consists_of)*/sci:O13_triggers ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  $current a crm:E55_Type .
+}
+```

--- a/docs/api/rels/1/workLanguageLanguage.md
+++ b/docs/api/rels/1/workLanguageLanguage.md
@@ -21,7 +21,18 @@ From the record for English, the record for the Lord of the Rings would be in th
 
 
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P72_has_language $language .
+  } UNION {
+    $current crm:P72i_is_language_of ?work .
+  }
+  ?work a crm:E33_Linguistic_Object .
+  FILTER(isIRI(?work))
+}
+```

--- a/docs/api/rels/1/workMemberOfSet.md
+++ b/docs/api/rels/1/workMemberOfSet.md
@@ -12,16 +12,28 @@ See the related [model documentation](/model/collection/#features)
 
 From the record for the set of works which describe the Night Watch, the record for Bikker's "The Night Watch" would be in the response
 
-
 ### Details
 
 * Class Given: Set
 * Returns Class: Work
 * Relationship: memberOf
 
-
 ### SPARQL
+
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX la: <https://linked.art/ns/terms/>
+
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work la:member_of $current .
+  } UNION {
+    $current la:has_member ?work .
+  }
+  ?work a crm:E33_Linguistic_Object .
+  FILTER(isIRI(?work))
+}
 ```
 
-```
-
+> Require metatype for "Type of Work"?

--- a/docs/api/rels/1/workPartOfWork.md
+++ b/docs/api/rels/1/workPartOfWork.md
@@ -12,16 +12,25 @@ See the related [model documentation](/model/document/#structure)
 
 From the record for The Lord of the Rings, the record for The Fellowship of the Ring would be in the response
 
-
 ### Details
 
 * Class Given: Work
 * Returns Class: Work
 * Relationship: partOf
 
-
 ### SPARQL
-```
 
 ```
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    $current crm:P106i_forms_part_of ?work .
+  } UNION {
+    ?work crm:P106_is_composed_of ?work .
+  }
+  ?work a crm:E33_Linguistic_Object .
+  FILTER(isIRI(?work))
+}
+```

--- a/docs/api/rels/1/workPublishedAtPlace.md
+++ b/docs/api/rels/1/workPublishedAtPlace.md
@@ -12,19 +12,35 @@ See the related [model documentation](/model/document/#creation-and-publication)
 
 From the record for Los Angeles, the Getty Exhibition catalog for Pacific Standard Time would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Work
 * Relationship: publishedAt
 
-
 ### SPARQL
-```
-SELECT DISTINCT ?work WHERE {
-     BIND(<%current%> as ?where)
-     ?activity ^crm:P16i_was_used_for ?work ;         crm:P2_has_type <http://vocab.getty.edu/aat/300054686> ;         crm:P9_consists_of*/crm:P7_took_place_at ?where .
- } 
-```
 
+```
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P16i_was_used_for/(crm:P9_consists_of|crm:P9i_forms_part_of)* ?activity .
+  } UNION {
+    ?activity (crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P16_used_specific_object ?work .
+  }
+  {
+    ?activity crm:P2_has_type <http://vocab.getty.edu/aat/300054686> .
+  } UNION {
+    <http://vocab.getty.edu/aat/300054686> crm:P2i_is_type_of ?activity .
+  }
+  {
+    ?activity crm:P7_took_place_at $current .
+  } UNION {
+    $current crm:P7i_witnessed ?activity .
+  }
+  ?work a crm:E33_Linguistic_Object .
+  FILTER(isIRI(?work))
+}
+```

--- a/docs/api/rels/1/workPublishedByAgent.md
+++ b/docs/api/rels/1/workPublishedByAgent.md
@@ -29,3 +29,28 @@ SELECT DISTINCT ?work WHERE {
  } 
 ```
 
+
+```
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P16i_was_used_for/(crm:P9_consists_of|crm:P9i_forms_part_of)* ?activity .
+  } UNION {
+    ?activity (crm:P9_consists_of|crm:P9i_forms_part_of)*/crm:P16_used_specific_object ?work .
+  }
+  {
+    ?activity crm:P2_has_type <http://vocab.getty.edu/aat/300054686> .
+  } UNION {
+    <http://vocab.getty.edu/aat/300054686> crm:P2i_is_type_of ?activity .
+  }
+  {
+    ?activity crm:P14_carried_out_by $current .
+  } UNION {
+    $current crm:P14i_performed ?activity .
+  }
+  ?work a crm:E33_Linguistic_Object .
+  FILTER(isIRI(?work))
+}
+```

--- a/docs/api/rels/1/workRepresentsActivity.md
+++ b/docs/api/rels/1/workRepresentsActivity.md
@@ -12,16 +12,36 @@ See the related [model documentation](/model/object/aboutness/#depiction)
 
 From the record for the activity of the Battle of Bunker Hill, the record for the image created by Trumbull of the painting of the same name would be in the response
 
-
 ### Details
 
 * Class Given: Temporal
 * Returns Class: Work
 * Relationship: 
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P138_represents $current .
+  } UNION {
+    $current crm:P138i_has_representation ?work .
+  }
+  {
+    $current a crm:E4_Period .
+  } UNION {
+    $current a crm:E5_Event .
+  } UNION {
+    $current a crm:E7_Activity .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  FILTER(isIRI(?work))
+}
+```

--- a/docs/api/rels/1/workRepresentsAgent.md
+++ b/docs/api/rels/1/workRepresentsAgent.md
@@ -28,3 +28,26 @@ SELECT DISTINCT ?work WHERE {
  } 
 ```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P138_represents $current .
+  } UNION {
+    $current crm:P138i_has_representation ?work .
+  }
+  {
+    $current a crm:E21_Person .
+  } UNION {
+    $current a crm:E76_Group .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  FILTER(isIRI(?work))
+}
+```

--- a/docs/api/rels/1/workRepresentsConcept.md
+++ b/docs/api/rels/1/workRepresentsConcept.md
@@ -12,16 +12,30 @@ See the related [model documentation](/model/object/aboutness/#depiction)
 
 From the record for the concept of Dogs, the record for the work of the Night Watch would be in the response (as the image depicts an unidentified dog)
 
-
 ### Details
 
 * Class Given: Concept
 * Returns Class: Work
 * Relationship: represents
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P138_represents|crm:P199_represents_instance_of_type $current .
+  } UNION {
+    $current crm:P138i_has_representation|crm:P199i_has_instance_represented_by ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  $current a crm:E55_Type .
+  FILTER(isIRI(?work))
+}
+```

--- a/docs/api/rels/1/workRepresentsObject.md
+++ b/docs/api/rels/1/workRepresentsObject.md
@@ -12,16 +12,30 @@ See the related [model documentation](/model/object/aboutness/#depiction)
 
 From the record for the Night Watch, the record for a photograph of the Night Watch would be in the response
 
-
 ### Details
 
 * Class Given: HumanMadeObject
 * Returns Class: Work
 * Relationship: represents
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P138_represents $current .
+  } UNION {
+    $current crm:P138i_has_representation ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  $current a crm:E21_Human-Made_Object .
+  FILTER(isIRI(?work))
+}
+```

--- a/docs/api/rels/1/workRepresentsPlace.md
+++ b/docs/api/rels/1/workRepresentsPlace.md
@@ -12,19 +12,30 @@ See the related [model documentation](/model/object/aboutness/#depiction)
 
 From the record for Paris France, the record for Pissarro's "Boulevard Montmartre at Night" would be in the response
 
-
 ### Details
 
 * Class Given: Place
 * Returns Class: Work
 * Relationship: represents
 
-
 ### SPARQL
-```
-PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/> SELECT DISTINCT ?work WHERE {
-   BIND(<%current%>as ?where)
-   ?work crm:P138_represents ?where .
-  }
-```
 
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P138_represents $current .
+  } UNION {
+    $current crm:P138i_has_representation ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  $current a crm:E53_Place .
+  FILTER(isIRI(?work))
+}
+```

--- a/docs/api/rels/1/workRepresentsSet.md
+++ b/docs/api/rels/1/workRepresentsSet.md
@@ -12,16 +12,31 @@ See the related [model documentation](/model/object/aboutness/#depiction)
 
 From the record for the set for the Archives of O. C. Marsh, an image that depicts the archive would be in the response
 
-
 ### Details
 
 * Class Given: Set
 * Returns Class: Work
 * Relationship: represents
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+PREFIX la: <https://linked.art/ns/terms/>
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P138_represents $current .
+  } UNION {
+    $current crm:P138i_has_representation ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  $current a la:Set .
+  FILTER(isIRI(?work))
+}
+```

--- a/docs/api/rels/1/workRepresentsWork.md
+++ b/docs/api/rels/1/workRepresentsWork.md
@@ -19,9 +19,28 @@ See the related [model documentation](/model/object/aboutness/#depiction)
 * Returns Class: Work
 * Relationship: represents
 
-
 ### SPARQL
-```
 
-```
+```sparql
+PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
 
+SELECT DISTINCT ?work
+WHERE {
+  {
+    ?work crm:P138_represents $current .
+  } UNION {
+    $current crm:P138i_has_representation ?work .
+  }
+  {
+    ?work a crm:E33_Linguistic_Object .
+  } UNION {
+    ?work a crm:E36_Visual_Item .
+  }
+  {
+    $current a crm:E33_Linguistic_Object .
+  } UNION {
+    $current a crm:E36_Visual_Item .
+  }
+  FILTER(isIRI(?work))
+}
+```


### PR DESCRIPTION
This PR extends the [Search Links](https://linked.art/api/1.0/hal/) area of the documentation by adding and extending SPARQL queries. It also refactors some of the existing queries.

I'm proposing to change the variable templating pattern a little, so that the examples are natively valid SPARQL but can also be used as string templates in code. This is done by using the `$` character for variables which can be templated, which according to [_4.1.3 Syntax for Query Variables_ in SPARQL 1.1 Query Language](https://www.w3.org/TR/sparql11-query/) is as equally valid as `?`. For example, instead of:

```sparql
SELECT DISTINCT ?activity
WHERE {
  BIND (<%current%>AS ?group)
  ?activity crm:P14_carried_out_by ?group .
}
```

I propose...

```sparql
SELECT DISTINCT ?activity
WHERE {
  ?activity crm:P14_carried_out_by $current .
}
```

... or potentially if we prefer the `BIND` as an entrypoint...

```sparql
SELECT DISTINCT ?activity
WHERE {
  BIND($current AS ?group)
  ?activity crm:P14_carried_out_by ?group .
}
```

... so that the query can be executed as is, validated, linted, or constrained by replacing the template variable. In Python, for example:

```python
>>> from string import Template
>>> template = Template('?activity crm:P14_carried_out_by $current .')
>>> template.safe_substitute(current='<http://example.org/activity/1>')
'?activity crm:P14_carried_out_by <http://example.org/activity/1> .'
```

Other languages could use a regular expression like `(\$\w+)`.

Aside from these changes to the templating pattern, this PR also provides queries in an ontologically symmetrical form. Thus both the direct and inverse properties are tested, with `UNION` preferred over `OPTIONAL` [for performance reasons](https://www.bobdc.com/blog/dropping-optional-blocks-from/).

```sparql
PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>

SELECT DISTINCT ?activity
WHERE {
  {
    ?activity crm:P14_carried_out_by $current .
  } UNION {
    $current crm:P14i_performed ?activity .
  }
}
```

I would like to consider with the community whether this symmetry is always necessary. I think it is useful for querying knowledge graphs which implement both the Linked Art Model and API document partitions (because part/whole and member/has_member are documented patterns), but is it perhaps going too far by testing the inverse of pure CRM patterns that Linked Art doesn't describe? For example, `crm:P98_brought_into_life` isn't a documented Linked Art property:

```sparql
WHERE {
  {
    ?person crm:P98i_was_born ?birth .
  } UNION {
    ?birth crm:P98_brought_into_life ?person .
  }
}
```

A further question here is whether or not the inverse properties should be provided in the query explicitly, or whether instead the ontologies (CRM, LA, SKOS, etc.) should be side-loaded and inferred against.

Relates to https://github.com/linked-art/linked.art/issues/763.