### PR TITLE
Refactor core.json schema

### DIFF
--- a/docs/api/1.0/schema/core.json
+++ b/docs/api/1.0/schema/core.json
@@ -438,9 +438,6 @@
                 "language": {
                     "$ref": "#/$defs/languageProp"
                 },
-                "referred_to_by": {
-                    "$ref": "#/$defs/referred_to_byProp"
-                },
                 "part": {
                     "description": "A list of one or more `Name` structures, which are parts of this `Name`",
                     "type": "array",
@@ -1372,12 +1369,10 @@
                 {
                     "title": "Linked Art with Extensions",
                     "type": "array",
-                    "items": [
-                        {
-                            "type": "string",
-                            "format": "uri"
-                        }
-                    ]
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    }
                 }
             ]
         },


### PR DESCRIPTION
Removing duplicate 'referred_to_by' property and updating 'items' definition for 'Linked Art with Extensions' to a single object format.

This lets [boon](https://github.com/santhosh-tekuri/boon) validate the schema successfully.